### PR TITLE
Remove extra qualification on an imported type

### DIFF
--- a/arm/src/rustler_util.rs
+++ b/arm/src/rustler_util.rs
@@ -1075,7 +1075,7 @@ impl<'a> RustlerDecoder<'a> for Delta {
             let witness: DeltaWitness = value.decode()?;
             Ok(Delta::Witness(witness))
         } else {
-            Err(rustler::Error::BadArg)
+            Err(Error::BadArg)
         }
     }
 }


### PR DESCRIPTION
rustler is already imported so rustler:: only adds noise

This is it's own topic as this is not related to any of the other changes I've done