### PR TITLE
Remove Value Checks for Ephemeral Resources

### DIFF
--- a/examples/simple_transfer_application/app/src/burn.rs
+++ b/examples/simple_transfer_application/app/src/burn.rs
@@ -84,7 +84,6 @@ fn simple_burn_test() {
     use arm::{
         action_tree::MerkleTree,
         authorization::{AuthorizationSigningKey, AuthorizationVerifyingKey},
-        evm::CallType,
         merkle_path::MerklePath,
         nullifier_key::NullifierKey,
     };
@@ -118,8 +117,6 @@ fn simple_burn_test() {
         consumed_nf.as_bytes().try_into().unwrap(), // nonce
         created_nf_cm,
         [6u8; 32], // rand_seed
-        CallType::Unwrap,
-        &user_addr, // user_addr
     );
     let created_cm = created_resource.commitment();
 

--- a/examples/simple_transfer_application/app/src/mint.rs
+++ b/examples/simple_transfer_application/app/src/mint.rs
@@ -88,7 +88,6 @@ fn simple_mint_test() {
         authorization::{AuthorizationSigningKey, AuthorizationVerifyingKey},
         compliance::INITIAL_ROOT,
         encryption::random_keypair,
-        evm::CallType,
         nullifier_key::NullifierKey,
     };
 
@@ -106,8 +105,6 @@ fn simple_mint_test() {
         [4u8; 32], // nonce
         consumed_nf_cm,
         [5u8; 32], // rand_seed
-        CallType::Wrap,
-        &user_addr,
     );
     let consumed_nf = consumed_resource.nullifier(&consumed_nf_key).unwrap();
     // Fetch the latest cm tree root from the chain

--- a/examples/simple_transfer_application/app/src/resource.rs
+++ b/examples/simple_transfer_application/app/src/resource.rs
@@ -1,11 +1,9 @@
 use crate::TransferLogic;
 use arm::{
-    authorization::AuthorizationVerifyingKey, evm::CallType, logic_proof::LogicProver,
-    nullifier_key::NullifierKeyCommitment, resource::Resource,
+    authorization::AuthorizationVerifyingKey, logic_proof::LogicProver,
+    nullifier_key::NullifierKeyCommitment, resource::Resource, Digest,
 };
-use simple_transfer_witness::{
-    calculate_label_ref, calculate_value_ref_calltype_user, calculate_value_ref_from_auth,
-};
+use simple_transfer_witness::{calculate_label_ref, calculate_value_ref_from_auth};
 
 #[allow(clippy::too_many_arguments)]
 pub fn construct_persistent_resource(
@@ -39,16 +37,13 @@ pub fn construct_ephemeral_resource(
     nonce: [u8; 32],
     nk_commitment: NullifierKeyCommitment,
     rand_seed: [u8; 32],
-    call_type: CallType,
-    user_addr: &[u8],
 ) -> Resource {
     let label_ref = calculate_label_ref(forwarder_addr, token_addr);
-    let value_ref = calculate_value_ref_calltype_user(call_type, user_addr);
     Resource {
         logic_ref: TransferLogic::verifying_key(),
         label_ref,
         quantity,
-        value_ref,
+        value_ref: Digest::from([0u8; 32]),
         is_ephemeral: true,
         nonce,
         nk_commitment,


### PR DESCRIPTION
Reverts the previous decision made in the hacker house for optimization purposes:

As the value of ephemeral resources do not matter, do not check them in-circuit.

IDs not yet regenerated, hence a draft.