### PR TITLE
replace thread_rng with OsRng

### DIFF
--- a/arm/src/compliance.rs
+++ b/arm/src/compliance.rs
@@ -17,8 +17,10 @@ use k256::{
     EncodedPoint, ProjectivePoint, Scalar,
 };
 use lazy_static::lazy_static;
+use rand::rngs::OsRng;
 use risc0_zkvm::Digest;
 use serde_with::serde_as;
+
 lazy_static! {
     pub static ref INITIAL_ROOT: Digest =
         Digest::from_hex("cc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b06")
@@ -70,12 +72,11 @@ impl ComplianceWitness {
         nf_key: NullifierKey,
         created_resource: Resource,
     ) -> Self {
-        let mut rng = rand::thread_rng();
         ComplianceWitness {
             consumed_resource,
             created_resource,
             merkle_path: MerklePath::empty(),
-            rcv: Scalar::random(&mut rng).to_bytes().to_vec(),
+            rcv: Scalar::random(&mut OsRng).to_bytes().to_vec(),
             nf_key,
             ephemeral_root: latest_root,
         }
@@ -87,12 +88,11 @@ impl ComplianceWitness {
         merkle_path: MerklePath,
         created_resource: Resource,
     ) -> Self {
-        let mut rng = rand::thread_rng();
         ComplianceWitness {
             consumed_resource,
             created_resource,
             merkle_path,
-            rcv: Scalar::random(&mut rng).to_bytes().to_vec(),
+            rcv: Scalar::random(&mut OsRng).to_bytes().to_vec(),
             nf_key,
             ephemeral_root: *INITIAL_ROOT,
         }

--- a/arm/src/logic_proof.rs
+++ b/arm/src/logic_proof.rs
@@ -10,6 +10,7 @@ use crate::{
     resource_logic::TrivialLogicWitness,
     utils::words_to_bytes,
 };
+use rand::rngs::OsRng;
 use rand::Rng;
 use risc0_zkvm::{serde::to_vec, sha::Digest};
 use serde::{Deserialize, Serialize};
@@ -149,16 +150,15 @@ impl PaddingResourceLogic {
         PaddingResourceLogic { witness }
     }
     pub fn create_padding_resource(nk_commitment: NullifierKeyCommitment) -> Resource {
-        let mut rng = rand::thread_rng();
         Resource {
             logic_ref: Self::verifying_key(),
             label_ref: Digest::default(),
             quantity: 0,
             value_ref: Digest::default(),
             is_ephemeral: true,
-            nonce: rng.gen(),
+            nonce: OsRng.gen(),
             nk_commitment,
-            rand_seed: rng.gen(),
+            rand_seed: OsRng.gen(),
         }
     }
 }

--- a/arm/src/nullifier_key.rs
+++ b/arm/src/nullifier_key.rs
@@ -1,5 +1,5 @@
 use crate::error::ArmError;
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 use risc0_zkvm::sha::{Digest, Impl, Sha256, DIGEST_BYTES};
 use serde::{Deserialize, Serialize};
 
@@ -25,8 +25,7 @@ impl NullifierKey {
     }
 
     pub fn random_pair() -> (NullifierKey, NullifierKeyCommitment) {
-        let mut rng = rand::thread_rng();
-        let rng_bytes: [u8; DIGEST_BYTES] = rng.gen();
+        let rng_bytes: [u8; DIGEST_BYTES] = OsRng.gen();
         let nf_key = NullifierKey::from_bytes(rng_bytes);
         let nk_commitment = nf_key.commit();
         (nf_key, nk_commitment)

--- a/arm/src/resource.rs
+++ b/arm/src/resource.rs
@@ -22,6 +22,7 @@ use k256::{
     elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest},
     ProjectivePoint, Scalar, Secp256k1,
 };
+use rand::rngs::OsRng;
 use rand::Rng;
 use risc0_zkvm::sha::{rust_crypto::Sha256 as Sha256Type, Impl, Sha256, DIGEST_BYTES};
 use risc0_zkvm::Digest;
@@ -58,7 +59,6 @@ impl Resource {
         nonce: Digest,
         nk_commitment: NullifierKeyCommitment,
     ) -> Self {
-        let mut rng = rand::thread_rng();
         Self {
             logic_ref,
             label_ref,
@@ -70,7 +70,7 @@ impl Resource {
                 .try_into()
                 .expect("it can not fail since the digest length is always 32 bytes"),
             nk_commitment,
-            rand_seed: rng.gen(),
+            rand_seed: OsRng.gen(),
         }
     }
 
@@ -222,8 +222,7 @@ impl Resource {
     }
 
     pub fn reset_randomness(&mut self) {
-        let mut rng = rand::thread_rng();
-        self.rand_seed = rng.gen();
+        self.rand_seed = OsRng.gen();
     }
 
     pub fn set_nonce(&mut self, nf: Digest) {

--- a/examples/kudo_application/app/src/burn_tx.rs
+++ b/examples/kudo_application/app/src/burn_tx.rs
@@ -16,7 +16,7 @@ use kudo_logic_witness::{
     AUTH_SIGNATURE_DOMAIN,
 };
 use kudo_traits::burn::Burn;
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 
 pub fn build_burn_tx(
     issuer_sk: &AuthorizationSigningKey,
@@ -46,8 +46,7 @@ pub fn build_burn_tx(
 
     // Construct the ephemeral denomination resource
     let denomination_logic = SimpleDenominationInfo::verifying_key();
-    let mut rng = rand::thread_rng();
-    let nonce: [u8; 32] = rng.gen(); // Random nonce for the ephemeral resource
+    let nonce: [u8; 32] = OsRng.gen(); // Random nonce for the ephemeral resource
     let ephemeral_denomination_resource = Resource::create(
         denomination_logic,
         ephemeral_kudo_resource_cm, // Use the ephemeral kudo commitment as the label

--- a/examples/kudo_application/app/src/issue_tx.rs
+++ b/examples/kudo_application/app/src/issue_tx.rs
@@ -20,7 +20,7 @@ use kudo_logic_witness::{
     AUTH_SIGNATURE_DOMAIN,
 };
 use kudo_traits::issue::Issue;
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 
 pub fn build_issue_tx(
     issuer_sk: &AuthorizationSigningKey,
@@ -37,8 +37,7 @@ pub fn build_issue_tx(
     let kudo_value = compute_kudo_value(receiver_pk);
 
     // Construct the ephemeral kudo resource
-    let mut rng = rand::thread_rng();
-    let nonce: [u8; 32] = rng.gen(); // Random nonce for the ephemeral resource
+    let nonce: [u8; 32] = OsRng.gen(); // Random nonce for the ephemeral resource
     let ephemeral_kudo_resource = Resource::create(
         kudo_logic,
         kudo_lable,
@@ -63,7 +62,7 @@ pub fn build_issue_tx(
     let issued_kudo_resource_cm = issued_kudo_resource.commitment();
 
     // Construct the issued receive logic resource
-    let nonce: [u8; 32] = rng.gen(); // Random nonce for the ephemeral resource
+    let nonce: [u8; 32] = OsRng.gen(); // Random nonce for the ephemeral resource
     let issued_receive_resource = Resource::create(
         SimpleReceiveInfo::verifying_key(),
         issued_kudo_resource_cm,

--- a/examples/kudo_application/app/src/swap_tx.rs
+++ b/examples/kudo_application/app/src/swap_tx.rs
@@ -21,7 +21,7 @@ use kudo_logic_witness::{
     AUTH_SIGNATURE_DOMAIN,
 };
 use kudo_traits::swap::Swap;
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 
 #[allow(clippy::too_many_arguments)]
 pub fn build_swap_tx(
@@ -61,8 +61,7 @@ pub fn build_swap_tx(
 
     // Construct the denomination resource corresponding to the consumed kudo resource
     let denomination_logic = SimpleDenominationInfo::verifying_key();
-    let mut rng = rand::thread_rng();
-    let nonce: [u8; 32] = rng.gen(); // Random nonce for the ephemeral resource
+    let nonce: [u8; 32] = OsRng.gen(); // Random nonce for the ephemeral resource
     let consumed_denomination_resource = Resource::create(
         denomination_logic,
         consumed_kudo_nf, // Use the consumed kudo nullifier as the label

--- a/examples/kudo_application/app/src/transfer_tx.rs
+++ b/examples/kudo_application/app/src/transfer_tx.rs
@@ -21,7 +21,7 @@ use kudo_logic_witness::{
     AUTH_SIGNATURE_DOMAIN,
 };
 use kudo_traits::transfer::Transfer;
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 
 #[allow(clippy::too_many_arguments)]
 pub fn build_transfer_tx(
@@ -59,8 +59,7 @@ pub fn build_transfer_tx(
 
     // Construct the denomination resource corresponding to the consumed kudo resource
     let denomination_logic = SimpleDenominationInfo::verifying_key();
-    let mut rng = rand::thread_rng();
-    let nonce: [u8; 32] = rng.gen(); // Random nonce for the ephemeral resource
+    let nonce: [u8; 32] = OsRng.gen(); // Random nonce for the ephemeral resource
     let consumed_denomination_resource = Resource::create(
         denomination_logic,
         consumed_kudo_nf, // Use the consumed kudo nullifier as the label

--- a/examples/kudo_application/logic_witness/src/kudo_main_witness.rs
+++ b/examples/kudo_application/logic_witness/src/kudo_main_witness.rs
@@ -9,7 +9,7 @@ use arm::{
     nullifier_key::NullifierKey,
     resource::Resource,
 };
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 use risc0_zkvm::sha::{Impl, Sha256};
 use serde::{Deserialize, Serialize};
 
@@ -155,7 +155,6 @@ impl KudoMainWitness {
         owner: AuthorizationVerifyingKey,
         receiver_signature: AuthorizationSignature,
     ) -> Self {
-        let mut rng = rand::thread_rng();
         Self {
             kudo_resource,
             kudo_existence_path,
@@ -163,7 +162,7 @@ impl KudoMainWitness {
             kudo_nf_key: NullifierKey::default(), // not used
             issuer,
             encryption_sk: SecretKey::random(),
-            encryption_nonce: rng.gen(),
+            encryption_nonce: OsRng.gen(),
             denomination_resource,
             denomination_existence_path,
             denomination_is_consumed,

--- a/examples/simple_counter_application/app/src/init.rs
+++ b/examples/simple_counter_application/app/src/init.rs
@@ -13,15 +13,14 @@ use arm::{
     transaction::{Delta, Transaction},
     Digest,
 };
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 
 // It creates a random label reference and a nullifier key for the
 // ephermeral counter resource.
 pub fn ephemeral_counter() -> (Resource, NullifierKey) {
-    let mut rng = rand::thread_rng();
     let (nf_key, nf_key_cm) = NullifierKey::random_pair();
-    let label_ref: [u8; 32] = rng.gen(); // Random label reference, it should be unique for each counter
-    let nonce: [u8; 32] = rng.gen(); // Random nonce for the ephemeral resource
+    let label_ref: [u8; 32] = OsRng.gen(); // Random label reference, it should be unique for each counter
+    let nonce: [u8; 32] = OsRng.gen(); // Random nonce for the ephemeral resource
     let ephemeral_resource = Resource::create(
         CounterLogic::verifying_key(),
         Digest::from(label_ref),


### PR DESCRIPTION
Although thread_rng() is initially seeded from OS entropy and is generally secure, for stronger guarantees it’s recommended to use OsRng directly.