### PR TITLE
check len in batch aggregation

### DIFF
--- a/arm_circuits/batch_aggregation/methods/guest/src/main.rs
+++ b/arm_circuits/batch_aggregation/methods/guest/src/main.rs
@@ -9,7 +9,13 @@ fn main() {
     let compliance_instances: Vec<ComplianceInstanceWords> = env::read();
     let compliance_key: Digest = env::read();
     let logic_instances: Vec<Vec<u32>> = env::read();
-    let logic_keys: Vec<Digest> = env::read(); // Assume same length as `logic_instances`. Else will panic.
+    let logic_keys: Vec<Digest> = env::read();
+
+    assert_eq!(
+        logic_instances.len(),
+        logic_keys.len(),
+        "Mismatched logic instances and keys lengths"
+    );
 
     // Verify the proofs.
     for ci in compliance_instances.iter() {


### PR DESCRIPTION
It is best practice to add a constraint that logic instances length == logic keys length to ensure this is the case and so it does not rely on the panic.

Although a minor circuit update, it changes the id and elf, which will be updated in the new version.