### PR TITLE
Add solana feature flag for SHA-256 delta proof hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "risc0-zkvm",
  "serde",
  "serde_with",
+ "sha2",
  "sha3",
  "slab",
  "thiserror 2.0.17",

--- a/arm/Cargo.toml
+++ b/arm/Cargo.toml
@@ -11,6 +11,7 @@ risc0-zkvm = { version = "3.0.3", features = ["std", "unstable"], default-featur
 serde = { version = "1.0.197", default-features = false }
 serde_with = "3.14.1"
 k256 = { version = "=0.13.3", features = ["arithmetic", "serde", "expose-field", "std", "ecdsa", "hash2curve"], default-features = false }
+sha2 = { version = "0.10", optional = true }
 sha3 = { version = "0.10", optional = true }
 rand = "0.8"
 bincode = "1.3.3"
@@ -26,6 +27,7 @@ slab = "0.4.11"
 [features]
 default = ["transaction", "prove"]
 transaction = ["compliance_circuit", "dep:sha3"]
+solana = ["transaction", "dep:sha2"]
 compliance_circuit = []
 prove = ["risc0-zkvm/prove"]
 bonsai = ["risc0-zkvm/bonsai"]

--- a/arm/src/delta_proof.rs
+++ b/arm/src/delta_proof.rs
@@ -6,7 +6,13 @@ use k256::{
 use serde::{Deserialize, Serialize};
 
 use crate::error::ArmError;
-use sha3::{Digest, Keccak256};
+
+// Conditionally use SHA-256 for Solana, Keccak-256 for EVM
+#[cfg(feature = "solana")]
+use sha2::{Digest, Sha256 as HashFunction};
+
+#[cfg(not(feature = "solana"))]
+use sha3::{Digest, Keccak256 as HashFunction};
 
 #[derive(Clone, Debug)]
 pub struct DeltaProof {
@@ -25,8 +31,8 @@ pub struct DeltaInstance {
 
 impl DeltaProof {
     pub fn prove(message: &[u8], witness: &DeltaWitness) -> Result<DeltaProof, ArmError> {
-        // Hash the message using Keccak256
-        let mut digest = Keccak256::new();
+        // Hash the message (SHA-256 for Solana, Keccak-256 for EVM)
+        let mut digest = HashFunction::new();
         digest.update(message);
 
         // Sign the hashed message using RFC6979
@@ -60,8 +66,8 @@ impl DeltaProof {
             return Err(ArmError::InvalidDeltaProof);
         }
 
-        // Hash the message using Keccak256
-        let mut digest = Keccak256::new();
+        // Hash the message (SHA-256 for Solana, Keccak-256 for EVM)
+        let mut digest = HashFunction::new();
         digest.update(message);
 
         // Verify the signature


### PR DESCRIPTION
- Add sha2 dependency (optional)
- Add 'solana' feature that enables SHA-256 instead of Keccak-256
- Conditionally select hash function based on feature flag
- Default behavior (Keccak-256) unchanged for EVM compatibility