### PR TITLE
Fix DeltaWitness serde Deserialize to match Serialize

### DIFF
--- a/arm/src/delta_proof.rs
+++ b/arm/src/delta_proof.rs
@@ -209,7 +209,12 @@ impl<'de> Deserialize<'de> for DeltaWitness {
     where
         D: serde::Deserializer<'de>,
     {
-        let bytes = <[u8; 32]>::deserialize(deserializer)?;
+        let bytes: Vec<u8> = Vec::deserialize(deserializer)?;
+        if bytes.len() != 32 {
+            return Err(serde::de::Error::custom(
+                "Invalid byte length for DeltaWitness",
+            ));
+        }
         DeltaWitness::from_bytes(&bytes).map_err(|e| {
             serde::de::Error::custom(format!("Failed to deserialize DeltaWitness: {:?}", e))
         })

--- a/arm/src/delta_proof.rs
+++ b/arm/src/delta_proof.rs
@@ -254,10 +254,6 @@ mod tests {
     }
 
     /// DeltaWitness: serialize then deserialize via bincode must round-trip.
-    ///
-    /// Serialize uses serialize_bytes (u64 length prefix + bytes) but
-    /// Deserialize reads [u8; 32] (fixed-size, no prefix). These are
-    /// incompatible in bincode, so the round-trip fails.
     #[test]
     fn delta_witness_bincode_roundtrip() {
         let mut rng = OsRng;

--- a/arm/src/delta_proof.rs
+++ b/arm/src/delta_proof.rs
@@ -216,18 +216,51 @@ impl<'de> Deserialize<'de> for DeltaWitness {
     }
 }
 
-#[test]
-fn test_delta_proof() {
+#[cfg(test)]
+mod tests {
+    use super::*;
     use k256::elliptic_curve::rand_core::OsRng;
 
-    let mut rng = OsRng;
-    let signing_key = SigningKey::random(&mut rng);
-    let verifying_key = VerifyingKey::from(&signing_key);
+    #[test]
+    fn test_delta_proof() {
+        let mut rng = OsRng;
+        let signing_key = SigningKey::random(&mut rng);
+        let verifying_key = VerifyingKey::from(&signing_key);
 
-    let message = b"Hello, world!";
-    let witness = DeltaWitness { signing_key };
-    let proof = DeltaProof::prove(message, &witness).unwrap();
-    let instance = DeltaInstance { verifying_key };
+        let message = b"Hello, world!";
+        let witness = DeltaWitness { signing_key };
+        let proof = DeltaProof::prove(message, &witness).unwrap();
+        let instance = DeltaInstance { verifying_key };
 
-    DeltaProof::verify(message, &proof, instance).unwrap();
+        DeltaProof::verify(message, &proof, instance).unwrap();
+    }
+
+    /// DeltaProof: serialize then deserialize via bincode must round-trip.
+    #[test]
+    fn delta_proof_bincode_roundtrip() {
+        let mut rng = OsRng;
+        let signing_key = SigningKey::random(&mut rng);
+        let witness = DeltaWitness { signing_key };
+        let proof = DeltaProof::prove(b"roundtrip", &witness).unwrap();
+
+        let encoded = bincode::serialize(&proof).unwrap();
+        let decoded: DeltaProof = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(proof, decoded);
+    }
+
+    /// DeltaWitness: serialize then deserialize via bincode must round-trip.
+    ///
+    /// Serialize uses serialize_bytes (u64 length prefix + bytes) but
+    /// Deserialize reads [u8; 32] (fixed-size, no prefix). These are
+    /// incompatible in bincode, so the round-trip fails.
+    #[test]
+    fn delta_witness_bincode_roundtrip() {
+        let mut rng = OsRng;
+        let signing_key = SigningKey::random(&mut rng);
+        let witness = DeltaWitness { signing_key };
+
+        let encoded = bincode::serialize(&witness).unwrap();
+        let decoded: DeltaWitness = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(witness, decoded);
+    }
 }


### PR DESCRIPTION
## Summary

- `DeltaWitness::Serialize` uses `serialize_bytes` which in bincode writes a `u64` length prefix + 32 bytes
- `DeltaWitness::Deserialize` reads `[u8; 32]` which expects 32 raw bytes with no prefix
- On roundtrip, the length prefix is silently consumed as signing key bytes, producing a **corrupted** `DeltaWitness` without erroring
- `DeltaProof` does not have this issue — its `Deserialize` already uses `Vec::deserialize`

Fix: change `DeltaWitness::Deserialize` to use `Vec::deserialize` with length validation, matching `DeltaProof`.

Closes #211

## Test plan

- `delta_witness_bincode_roundtrip` — failed before this fix (silent corruption), passes after
- `delta_proof_bincode_roundtrip` — passes before and after (no change)
- Full `cargo test -p anoma-rm-risc0` — all 6 tests pass

The demo branch [`bugfix/delta-witness-serde-mismatch`](https://github.com/anoma/arm-risc0/tree/bugfix/delta-witness-serde-mismatch) preserves the failing test without the fix for reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)