### PR TITLE
bump: solana-secp256k1 0.1 → 0.2.1, remove ecadd workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "hashbrown 0.16.0",
  "indexmap 2.11.4",
  "itoa",
- "k256 0.13.3",
+ "k256",
  "keccak-asm",
  "paste",
  "proptest",
@@ -268,7 +268,7 @@ dependencies = [
  "borsh 1.5.7",
  "bytemuck",
  "hex",
- "k256 0.13.3",
+ "k256",
  "lazy_static",
  "rand 0.8.5",
  "risc0-zkvm",
@@ -288,7 +288,7 @@ dependencies = [
  "anoma-rm-risc0",
  "bincode",
  "hex",
- "k256 0.13.3",
+ "k256",
  "rand 0.8.5",
  "serde",
  "zeroize",
@@ -301,7 +301,7 @@ dependencies = [
  "anoma-rm-risc0",
  "anoma-rm-risc0-test-witness",
  "hex",
- "k256 0.13.3",
+ "k256",
  "lazy_static",
  "serde",
  "sha3",
@@ -313,7 +313,7 @@ version = "1.1.1"
 dependencies = [
  "anoma-rm-risc0",
  "anoma-rm-risc0-gadgets",
- "k256 0.13.3",
+ "k256",
  "serde",
 ]
 
@@ -323,8 +323,7 @@ version = "1.0.0"
 dependencies = [
  "anoma-rm-core",
  "bytemuck",
- "dashu",
- "k256 0.13.3",
+ "k256",
  "sha2 0.10.9",
  "solana-program",
  "solana-secp256k1",
@@ -763,12 +762,6 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -1194,6 +1187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,12 +1245,6 @@ dependencies = [
  "proptest",
  "serde_core",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "const-oid"
@@ -1322,6 +1315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,9 +1377,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -1390,14 +1389,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
+ "cpubits",
+ "ctutils",
+ "num-traits",
 ]
 
 [[package]]
@@ -1412,22 +1410,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1575,99 +1572,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashu"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b3e5ac1e23ff1995ef05b912e2b012a8784506987a2651552db2c73fb3d7e0"
-dependencies = [
- "dashu-base",
- "dashu-float",
- "dashu-int",
- "dashu-macros",
- "dashu-ratio",
- "rustversion",
-]
-
-[[package]]
-name = "dashu-base"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b80bf6b85aa68c58ffea2ddb040109943049ce3fbdf4385d0380aef08ef289"
-
-[[package]]
-name = "dashu-float"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85078445a8dbd2e1bd21f04a816f352db8d333643f0c9b78ca7c3d1df71063e7"
-dependencies = [
- "dashu-base",
- "dashu-int",
- "num-modular",
- "num-order",
- "rustversion",
- "static_assertions",
-]
-
-[[package]]
-name = "dashu-int"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee99d08031ca34a4d044efbbb21dff9b8c54bb9d8c82a189187c0651ffdb9fbf"
-dependencies = [
- "cfg-if",
- "dashu-base",
- "num-modular",
- "num-order",
- "rustversion",
- "static_assertions",
-]
-
-[[package]]
-name = "dashu-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93381c3ef6366766f6e9ed9cf09e4ef9dec69499baf04f0c60e70d653cf0ab10"
-dependencies = [
- "dashu-base",
- "dashu-float",
- "dashu-int",
- "dashu-ratio",
- "paste",
- "proc-macro2",
- "quote",
- "rustversion",
-]
-
-[[package]]
-name = "dashu-ratio"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e33b04dd7ce1ccf8a02a69d3419e354f2bbfdf4eb911a0b7465487248764c9"
-dependencies = [
- "dashu-base",
- "dashu-float",
- "dashu-int",
- "num-modular",
- "num-order",
- "rustversion",
-]
-
-[[package]]
-name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid 0.7.1",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1772,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1869,28 +1779,16 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
-dependencies = [
- "der 0.5.1",
- "elliptic-curve 0.11.12",
- "rfc6979 0.1.0",
- "signature 1.4.0",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
+ "elliptic-curve",
+ "rfc6979",
  "serdect",
- "signature 2.2.0",
+ "signature",
  "spki",
 ]
 
@@ -1920,37 +1818,19 @@ checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.3.2",
- "der 0.5.1",
- "ff 0.11.1",
- "generic-array",
- "group 0.11.0",
- "rand_core 0.6.4",
- "sec1 0.2.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pkcs8",
  "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1",
  "serdect",
  "subtle",
  "zeroize",
@@ -2089,16 +1969,6 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
-
-[[package]]
-name = "ff"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "ff"
@@ -2467,22 +2337,11 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
-dependencies = [
- "ff 0.11.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2580,16 +2439,6 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
 
 [[package]]
 name = "hmac"
@@ -3019,29 +2868,17 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
-dependencies = [
- "cfg-if",
- "ecdsa 0.13.4",
- "elliptic-curve 0.11.12",
- "sec1 0.2.1",
-]
-
-[[package]]
-name = "k256"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "once_cell",
  "serdect",
  "sha2 0.10.9",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -3544,21 +3381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-modular"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
-
-[[package]]
-name = "num-order"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
-dependencies = [
- "num-modular",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3772,7 +3594,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
+ "der",
  "pkcs8",
  "spki",
 ]
@@ -3783,7 +3605,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "spki",
 ]
 
@@ -4358,22 +4180,11 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
-dependencies = [
- "crypto-bigint 0.3.2",
- "hmac 0.11.0",
- "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -4675,7 +4486,7 @@ dependencies = [
  "cfg-if",
  "cust",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "hex",
  "hex-literal",
  "metal",
@@ -4786,7 +4597,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
@@ -4794,7 +4605,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "signature 2.2.0",
+ "signature",
  "spki",
  "subtle",
  "zeroize",
@@ -5025,24 +4836,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
-dependencies = [
- "der 0.5.1",
- "generic-array",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
+ "base16ct",
+ "der",
  "generic-array",
  "pkcs8",
  "serdect",
@@ -5190,7 +4989,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "serde",
 ]
 
@@ -5243,16 +5042,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signature"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
-dependencies = [
- "digest 0.9.0",
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "signature"
@@ -5313,7 +5102,7 @@ checksum = "c8f5152a288ef1912300fc6efa6c2d1f9bb55d9398eb6c72326360b8063987da"
 dependencies = [
  "bincode",
  "serde",
- "solana-program-error",
+ "solana-program-error 2.2.2",
  "solana-program-memory",
  "solana-pubkey",
 ]
@@ -5410,7 +5199,7 @@ dependencies = [
  "solana-account-info",
  "solana-define-syscall",
  "solana-instruction",
- "solana-program-error",
+ "solana-program-error 2.2.2",
  "solana-pubkey",
  "solana-stable-layout",
 ]
@@ -5490,7 +5279,7 @@ dependencies = [
  "solana-account",
  "solana-account-info",
  "solana-instruction",
- "solana-program-error",
+ "solana-program-error 2.2.2",
  "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
@@ -5554,7 +5343,7 @@ dependencies = [
  "bitflags 2.9.4",
  "solana-account-info",
  "solana-instruction",
- "solana-program-error",
+ "solana-program-error 2.2.2",
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
@@ -5685,11 +5474,12 @@ dependencies = [
 
 [[package]]
 name = "solana-nostd-secp256k1-recover"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a430874217d3aa7802ca8c880c9938c0c8a9d480ab83c0a3535a2052069f87"
+checksum = "1b03f149b0d2eba4514f4444b7300ea65ee23f509b10417e13799517c28c2ebc"
 dependencies = [
- "k256 0.10.4",
+ "k256",
+ "solana-program-error 3.0.1",
 ]
 
 [[package]]
@@ -5746,7 +5536,7 @@ dependencies = [
  "solana-native-token",
  "solana-nonce",
  "solana-program-entrypoint",
- "solana-program-error",
+ "solana-program-error 2.2.2",
  "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
@@ -5780,7 +5570,7 @@ checksum = "32ce041b1a0ed275290a5008ee1a4a6c48f5054c8a3d78d313c08958a06aedbd"
 dependencies = [
  "solana-account-info",
  "solana-msg",
- "solana-program-error",
+ "solana-program-error 2.2.2",
  "solana-pubkey",
 ]
 
@@ -5799,6 +5589,12 @@ dependencies = [
  "solana-msg",
  "solana-pubkey",
 ]
+
+[[package]]
+name = "solana-program-error"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 
 [[package]]
 name = "solana-program-memory"
@@ -5821,7 +5617,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
 dependencies = [
- "solana-program-error",
+ "solana-program-error 2.2.2",
 ]
 
 [[package]]
@@ -5892,12 +5688,13 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4d0bbdde28e2eef1cbb2bf129beeffdd7c74ba96f9f790f6e71a2774e7ff1c"
+checksum = "0675ad548c832e19f920da37e088b5840426a531e633636b9bc6842fa0faf6b0"
 dependencies = [
- "dashu",
+ "crypto-bigint 0.7.3",
  "solana-nostd-secp256k1-recover",
+ "solana-program-error 3.0.1",
 ]
 
 [[package]]
@@ -6002,7 +5799,7 @@ dependencies = [
  "solana-cpi",
  "solana-decode-error",
  "solana-instruction",
- "solana-program-error",
+ "solana-program-error 2.2.2",
  "solana-pubkey",
  "solana-system-interface",
  "solana-sysvar-id",
@@ -6048,7 +5845,7 @@ dependencies = [
  "solana-instructions-sysvar",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
- "solana-program-error",
+ "solana-program-error 2.2.2",
  "solana-program-memory",
  "solana-pubkey",
  "solana-rent",
@@ -6121,7 +5918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]

--- a/arm_solana/Cargo.toml
+++ b/arm_solana/Cargo.toml
@@ -10,9 +10,8 @@ arm-core = { package = "anoma-rm-core", path = "../arm_core", features = [
   "borsh",
 ] }
 solana-program = "2.1"
-solana-secp256k1 = "0.1"
+solana-secp256k1 = "0.2.1"
 sha2 = "0.10"
-dashu = "0.4"
 bytemuck = { version = "1.12", features = ["derive"] }
 thiserror = "2.0.6"
 

--- a/arm_solana/src/delta.rs
+++ b/arm_solana/src/delta.rs
@@ -2,15 +2,15 @@
 //!
 //! Uses Solana syscalls (hashv, secp256k1_recover) and solana-secp256k1 for
 //! EC point arithmetic instead of k256, which exceeds SBF stack frame limits.
+//! Requires solana-secp256k1 >= 0.2.1 for correct modular subtraction in ecadd.
 
 use arm_core::compliance::ComplianceInstance;
 use arm_core::transaction::{Delta, Transaction};
 
 use crate::error::SolanaArmError;
-use dashu::integer::UBig;
 use solana_program::hash::hashv;
 use solana_program::secp256k1_recover::secp256k1_recover;
-use solana_secp256k1::{Curve, Secp256k1Point, UncompressedPoint};
+use solana_secp256k1::{Secp256k1, Secp256k1Point, UncompressedPoint};
 
 /// Scalar value 2 as a big-endian 32-byte array, used for EC point doubling.
 const SCALAR_TWO: [u8; 32] = {
@@ -64,10 +64,7 @@ fn words_to_bytes(words: &[u32; 8]) -> [u8; 32] {
 ///
 /// The curve equation check (y² = x³ + 7 mod p) is intentionally omitted here.
 /// The delta coordinates come from a verified Groth16 proof — the compliance circuit
-/// guarantees they are valid secp256k1 points. Performing a redundant curve check
-/// would pull in dashu big-integer arithmetic that has known issues on SBF
-/// (the `UBig` subtraction in `solana_secp256k1`'s EC point addition panics
-/// when the minuend is smaller than the subtrahend, because `UBig` is unsigned).
+/// guarantees they are valid secp256k1 points.
 fn parse_delta_point(x_words: &[u32; 8], y_words: &[u32; 8]) -> UncompressedPoint {
     let x_bytes = words_to_bytes(x_words);
     let y_bytes = words_to_bytes(y_words);
@@ -76,57 +73,6 @@ fn parse_delta_point(x_words: &[u32; 8], y_words: &[u32; 8]) -> UncompressedPoin
     point_bytes[..32].copy_from_slice(&x_bytes);
     point_bytes[32..].copy_from_slice(&y_bytes);
     UncompressedPoint(point_bytes)
-}
-
-/// Convert a `UBig` to a fixed-size 32-byte big-endian array, zero-padding on the left.
-fn ubig_to_be_bytes_32(n: &UBig) -> [u8; 32] {
-    let bytes = n.to_be_bytes();
-    let mut result = [0u8; 32];
-    let len = bytes.len().min(32);
-    result[32 - len..].copy_from_slice(&bytes[..len]);
-    result
-}
-
-/// EC point addition on secp256k1 with correct modular arithmetic.
-///
-/// This replaces the `Add<UncompressedPoint>` impl from `solana_secp256k1` which
-/// has a bug: it computes `x_q - x_p` as a raw `UBig` subtraction that panics
-/// when `x_q < x_p` (since `UBig` is unsigned and cannot represent negative values).
-/// The fix is to add the field prime `p` before subtracting, ensuring all
-/// intermediate values remain non-negative.
-fn ecadd(
-    a: &UncompressedPoint,
-    b: &UncompressedPoint,
-) -> Result<UncompressedPoint, SolanaArmError> {
-    let p = UBig::from_be_bytes(&Curve::P);
-
-    let x_a = UBig::from_be_bytes(&a.x());
-    let y_a = UBig::from_be_bytes(&a.y());
-    let x_b = UBig::from_be_bytes(&b.x());
-    let y_b = UBig::from_be_bytes(&b.y());
-
-    // dx = (x_b - x_a) mod p
-    // Add p before subtracting to prevent unsigned underflow.
-    let dx = (&x_b + &p - &x_a) % &p;
-    let dx_bytes = ubig_to_be_bytes_32(&dx);
-    let inv_dx = Curve::mod_inv_p(&dx_bytes).map_err(|_| SolanaArmError::DeltaPointNotOnCurve)?;
-    let inv_dx = UBig::from_be_bytes(&inv_dx);
-
-    // λ = (y_b - y_a) * (x_b - x_a)^{-1} mod p
-    let lambda = ((&y_b + &p - &y_a) * &inv_dx) % &p;
-
-    // x_r = λ² - x_a - x_b mod p
-    // Add 2p since x_a + x_b can be up to 2(p-1).
-    let x_r = (&lambda * &lambda + &p + &p - &x_a - &x_b) % &p;
-
-    // y_r = λ(x_a - x_r) - y_a mod p
-    let y_r = (&lambda * (&x_a + &p - &x_r) + &p - &y_a) % &p;
-
-    let mut result = [0u8; 64];
-    result[..32].copy_from_slice(&ubig_to_be_bytes_32(&x_r));
-    result[32..].copy_from_slice(&ubig_to_be_bytes_32(&y_r));
-
-    Ok(UncompressedPoint(result))
 }
 
 /// Accumulate delta points from all compliance instances using EC point addition.
@@ -150,7 +96,7 @@ pub fn accumulate_deltas(tx: &Transaction) -> Result<Option<UncompressedPoint>, 
                         if acc.y() == point.y() {
                             // Point doubling: P + P
                             Some(
-                                Curve::ecmul(&acc, &SCALAR_TWO)
+                                Secp256k1::ecmul(&acc, &SCALAR_TWO)
                                     .map_err(|_| SolanaArmError::DeltaPointNotOnCurve)?,
                             )
                         } else {
@@ -158,9 +104,7 @@ pub fn accumulate_deltas(tx: &Transaction) -> Result<Option<UncompressedPoint>, 
                             None
                         }
                     } else {
-                        // Point addition using our correct implementation,
-                        // not solana_secp256k1's buggy `+` operator.
-                        Some(ecadd(&acc, &point)?)
+                        Some(acc + point)
                     }
                 }
             };
@@ -460,7 +404,7 @@ mod tests {
         );
     }
 
-    /// Verify our ecadd produces the same result as k256 for G + 2G.
+    /// Verify the crate's + operator produces the same result as k256 for G + 2G.
     #[test]
     fn test_ecadd_matches_k256() {
         use k256::elliptic_curve::sec1::ToEncodedPoint;
@@ -472,11 +416,11 @@ mod tests {
         let expected_x: [u8; 32] = encoded.x().unwrap().as_slice().try_into().unwrap();
         let expected_y: [u8; 32] = encoded.y().unwrap().as_slice().try_into().unwrap();
 
-        // Compute G + 2G using our ecadd
+        // Compute G + 2G using solana-secp256k1's + operator
         let (gx, gy) = generator_words();
         let g_point = parse_delta_point(&gx, &gy);
-        let two_g_result = Curve::ecmul(&g_point, &SCALAR_TWO).unwrap();
-        let three_g_result = ecadd(&g_point, &two_g_result).unwrap();
+        let two_g_result = Secp256k1::ecmul(&g_point, &SCALAR_TWO).unwrap();
+        let three_g_result = g_point + two_g_result;
 
         assert_eq!(
             three_g_result.x(),
@@ -490,7 +434,7 @@ mod tests {
         );
     }
 
-    /// Verify ecadd is commutative: A + B == B + A.
+    /// Verify the + operator is commutative: A + B == B + A.
     #[test]
     fn test_ecadd_commutative() {
         use k256::elliptic_curve::sec1::ToEncodedPoint;
@@ -506,8 +450,8 @@ mod tests {
         let two_g_words = (words_from_bytes(x2), words_from_bytes(y2));
         let two_g_point = parse_delta_point(&two_g_words.0, &two_g_words.1);
 
-        let ab = ecadd(&g_point, &two_g_point).unwrap();
-        let ba = ecadd(&two_g_point, &g_point).unwrap();
+        let ab = g_point + two_g_point;
+        let ba = two_g_point + g_point;
 
         assert_eq!(ab.0, ba.0, "ecadd must be commutative");
     }
@@ -543,9 +487,8 @@ mod tests {
     // =========================================================================
 
     /// Regression test: EC point addition where the second point's x-coordinate
-    /// is numerically smaller than the first, triggering the unsigned underflow
-    /// bug in solana_secp256k1's `Add<UncompressedPoint>` impl. Our `ecadd`
-    /// handles this correctly by adding `p` before subtraction.
+    /// is numerically smaller than the first. This triggered a panic in
+    /// solana_secp256k1 < 0.2.1 due to raw UBig subtraction without adding p.
     #[test]
     fn test_ecadd_does_not_panic_on_smaller_x() {
         use k256::elliptic_curve::sec1::ToEncodedPoint;
@@ -557,33 +500,29 @@ mod tests {
         let g_encoded = k256::AffinePoint::GENERATOR.to_encoded_point(false);
         let two_g_encoded = two_g.to_encoded_point(false);
 
-        let g_x = UBig::from_be_bytes(g_encoded.x().unwrap().as_slice());
-        let two_g_x = UBig::from_be_bytes(two_g_encoded.x().unwrap().as_slice());
+        let g_x: [u8; 32] = g_encoded.x().unwrap().as_slice().try_into().unwrap();
+        let two_g_x: [u8; 32] = two_g_encoded.x().unwrap().as_slice().try_into().unwrap();
 
-        // Determine which has the smaller x, then call ecadd with smaller-x second
+        // Determine which has the smaller x, then add with smaller-x second.
+        // Big-endian [u8; 32] comparison is equivalent to numerical comparison.
         let (first, second) = if g_x > two_g_x {
-            let first_x: [u8; 32] = g_encoded.x().unwrap().as_slice().try_into().unwrap();
             let first_y: [u8; 32] = g_encoded.y().unwrap().as_slice().try_into().unwrap();
-            let second_x: [u8; 32] = two_g_encoded.x().unwrap().as_slice().try_into().unwrap();
             let second_y: [u8; 32] = two_g_encoded.y().unwrap().as_slice().try_into().unwrap();
             (
-                parse_delta_point(&words_from_bytes(first_x), &words_from_bytes(first_y)),
-                parse_delta_point(&words_from_bytes(second_x), &words_from_bytes(second_y)),
+                parse_delta_point(&words_from_bytes(g_x), &words_from_bytes(first_y)),
+                parse_delta_point(&words_from_bytes(two_g_x), &words_from_bytes(second_y)),
             )
         } else {
-            let first_x: [u8; 32] = two_g_encoded.x().unwrap().as_slice().try_into().unwrap();
             let first_y: [u8; 32] = two_g_encoded.y().unwrap().as_slice().try_into().unwrap();
-            let second_x: [u8; 32] = g_encoded.x().unwrap().as_slice().try_into().unwrap();
             let second_y: [u8; 32] = g_encoded.y().unwrap().as_slice().try_into().unwrap();
             (
-                parse_delta_point(&words_from_bytes(first_x), &words_from_bytes(first_y)),
-                parse_delta_point(&words_from_bytes(second_x), &words_from_bytes(second_y)),
+                parse_delta_point(&words_from_bytes(two_g_x), &words_from_bytes(first_y)),
+                parse_delta_point(&words_from_bytes(g_x), &words_from_bytes(second_y)),
             )
         };
 
-        // This must NOT panic (the bug in solana_secp256k1 would panic here)
-        let result = ecadd(&first, &second);
-        assert!(result.is_ok(), "ecadd must handle x_b < x_a");
+        // This must NOT panic (solana_secp256k1 < 0.2.1 would panic here)
+        let _ = first + second;
     }
 
     /// Regression test using delta coordinates from a real split withdrawal


### PR DESCRIPTION
* solana-secp256k1 0.2.1 fixes the UBig unsigned underflow panic, bump solana-secp256k1 to 0.2.1
* Remove the in-tree ecadd workaround and the dashu dependency
* Replace Curve (renamed to Secp256k1 in 0.2.1) at all call sites. Import Secp256k1Point explicitly since .x() / .y() are now trait methods.
* Update regression tests to exercise the crate's + operator directly rather than the removed ecadd function. All 12 tests pass including both split-transaction regression cases.