### PR TITLE
rename MerkleTree and merkle path

### DIFF
--- a/arm/src/action.rs
+++ b/arm/src/action.rs
@@ -2,7 +2,7 @@
 //! correspond to its consumed and created resources.
 
 use crate::{
-    action_tree::MerkleTree,
+    action_tree::ActionTree,
     compliance_unit::ComplianceUnit,
     error::ArmError,
     logic_proof::{LogicVerifier, LogicVerifierInputs},
@@ -129,7 +129,7 @@ impl Action {
     /// commitments. Any other ordering (e.g. sorting) will produce a different
     /// root and the resulting action's logic proofs will fail to verify with
     /// a generic proof-verification error.
-    pub fn construct_action_tree(tags: &[Digest]) -> MerkleTree {
-        MerkleTree::new(tags.to_vec())
+    pub fn construct_action_tree(tags: &[Digest]) -> ActionTree {
+        ActionTree::new(tags.to_vec())
     }
 }

--- a/arm/src/action_tree.rs
+++ b/arm/src/action_tree.rs
@@ -1,4 +1,4 @@
-//! Merkle tree implementation for the action tree.
+//! Action tree implementation.
 
 use crate::{
     error::ArmError,
@@ -7,25 +7,25 @@ use crate::{
 };
 use risc0_zkvm::sha::Digest;
 
-/// A Merkle tree structure.
+/// The action tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MerkleTree {
-    /// The leaves of the Merkle tree.
+pub struct ActionTree {
+    /// The leaves of the action tree.
     pub leaves: Vec<Digest>,
 }
 
-impl MerkleTree {
-    /// Creates a new Merkle tree from the given leaves.
+impl ActionTree {
+    /// Creates a new action tree from the given leaves.
     pub fn new(leaves: Vec<Digest>) -> Self {
-        MerkleTree { leaves }
+        ActionTree { leaves }
     }
 
-    /// Inserts a new leaf into the Merkle tree.
+    /// Inserts a new leaf into the action tree.
     pub fn insert(&mut self, value: Digest) {
         self.leaves.push(value)
     }
 
-    /// Computes the root of the Merkle tree.
+    /// Computes the root of the action tree.
     pub fn root(&self) -> Result<Digest, ArmError> {
         if self.is_empty() {
             return Err(ArmError::EmptyTree);
@@ -47,19 +47,7 @@ impl MerkleTree {
         Ok(cur_layer[0])
     }
 
-    // Generate the merkle path for the current leave
-    /// Generates the Merkle path for a given leaf in the Merkle tree.
-    ///
-    /// # Arguments
-    ///
-    /// * `cur_leave` - The leaf value for which the Merkle path is to be generated.
-    ///
-    /// # Returns
-    ///
-    /// Returns an `Option` containing a `MerklePath` if the leaf exists in the tree.
-    /// The `MerklePath` is a vector of tuples, where each tuple contains:
-    /// - A `Digest` representing the sibling node's hash.
-    /// - A `bool` indicating whether the sibling is on the left (`true`) or right (`false`).
+    /// Generates the Merkle path for a given leaf in the action tree.
     ///
     /// Returns `ArmError::InvalidLeaf` if the leaf is not found in the tree.
     pub fn generate_path(&self, cur_leave: &Digest) -> Result<MerklePath, ArmError> {
@@ -112,14 +100,14 @@ impl MerkleTree {
         }
     }
 
-    /// Checks if the Merkle tree is empty.
+    /// Checks if the action tree is empty.
     pub fn is_empty(&self) -> bool {
         self.leaves.is_empty()
     }
 }
 
-impl From<Vec<Digest>> for MerkleTree {
+impl From<Vec<Digest>> for ActionTree {
     fn from(leaves: Vec<Digest>) -> Self {
-        MerkleTree::new(leaves)
+        ActionTree::new(leaves)
     }
 }

--- a/arm/src/compliance.rs
+++ b/arm/src/compliance.rs
@@ -185,7 +185,7 @@ impl ComplianceWitness {
             let commitment_tree_root = if w.resource.is_ephemeral {
                 self.ephemeral_root
             } else {
-                w.merkle_path.root(&resource_commitment)
+                w.cm_merkle_path.root(&resource_commitment)
             };
             // Reading `logic_ref` here forces it to be loaded from memory onto
             // the computational trace.

--- a/arm/src/resource.rs
+++ b/arm/src/resource.rs
@@ -337,7 +337,7 @@ pub struct ConsumedResourceWitness {
     /// The consumed resource.
     pub resource: Resource,
     /// The path from the consumed commitment to the root of the commitment tree.
-    pub merkle_path: MerklePath,
+    pub cm_merkle_path: MerklePath,
     /// Nullifier key of the consumed resource.
     pub nf_key: NullifierKey,
 }
@@ -347,7 +347,7 @@ impl ConsumedResourceWitness {
     pub fn from_resource(resource: Resource, nf_key: NullifierKey) -> ConsumedResourceWitness {
         ConsumedResourceWitness {
             resource,
-            merkle_path: MerklePath::empty(),
+            cm_merkle_path: MerklePath::empty(),
             nf_key,
         }
     }
@@ -357,11 +357,11 @@ impl ConsumedResourceWitness {
     pub fn from_resource_with_path(
         resource: Resource,
         nf_key: NullifierKey,
-        merkle_path: MerklePath,
+        cm_merkle_path: MerklePath,
     ) -> ConsumedResourceWitness {
         ConsumedResourceWitness {
             resource,
-            merkle_path,
+            cm_merkle_path,
             nf_key,
         }
     }
@@ -383,11 +383,11 @@ impl Default for ConsumedResourceWitness {
             rand_seed: [0u8; 32],
         };
 
-        let merkle_path = MerklePath::default();
+        let cm_merkle_path = MerklePath::default();
 
         Self {
             resource,
-            merkle_path,
+            cm_merkle_path,
             nf_key,
         }
     }

--- a/arm_tests/arm_test_app/src/lib.rs
+++ b/arm_tests/arm_test_app/src/lib.rs
@@ -40,13 +40,13 @@ pub struct TestLogic {
 impl TestLogic {
     pub fn new(
         resource: Resource,
-        receive_existence_path: MerklePath,
+        action_tree_path: MerklePath,
         nf_key: NullifierKey,
         is_consumed: bool,
     ) -> Self {
         let witness = TestLogicWitness {
             resource,
-            receive_existence_path,
+            action_tree_path,
             is_consumed,
             nf_key,
         };
@@ -187,8 +187,8 @@ impl Tester {
         let logic_verifiers = entries
             .into_iter()
             .map(|(tag, resource, nf_key, is_consumed)| {
-                let receive_existence_path = action_tree.generate_path(&tag).unwrap();
-                TestLogic::new(resource, receive_existence_path, nf_key, is_consumed)
+                let action_tree_path = action_tree.generate_path(&tag).unwrap();
+                TestLogic::new(resource, action_tree_path, nf_key, is_consumed)
                     .prove(ProofType::Succinct)
                     .unwrap()
             })

--- a/arm_tests/arm_test_witness/src/lib.rs
+++ b/arm_tests/arm_test_witness/src/lib.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TestLogicWitness {
     pub resource: Resource,
-    pub receive_existence_path: MerklePath,
+    pub action_tree_path: MerklePath,
     pub is_consumed: bool,
     pub nf_key: NullifierKey,
 }
@@ -27,7 +27,7 @@ impl LogicCircuit for TestLogicWitness {
     fn constrain(&self) -> Result<LogicInstance, ArmError> {
         // Load the self resource
         let tag = self.resource.tag(self.is_consumed, &self.nf_key)?;
-        let root = self.receive_existence_path.root(&tag);
+        let root = self.action_tree_path.root(&tag);
 
         // The test resource is ephemeral and has one quantity
         assert_eq!(self.resource.quantity, 1);
@@ -88,13 +88,13 @@ impl LogicCircuit for TestLogicWitness {
 impl TestLogicWitness {
     pub fn new(
         resource: Resource,
-        receive_existence_path: MerklePath,
+        action_tree_path: MerklePath,
         nf_key: NullifierKey,
         is_consumed: bool,
     ) -> Self {
         Self {
             resource,
-            receive_existence_path,
+            action_tree_path,
             is_consumed,
             nf_key,
         }
@@ -108,7 +108,7 @@ impl Default for TestLogicWitness {
                 quantity: 1,
                 ..Default::default()
             },
-            receive_existence_path: MerklePath::default(),
+            action_tree_path: MerklePath::default(),
             is_consumed: false,
             nf_key: NullifierKey::default(),
         }


### PR DESCRIPTION
## Summary

resolve #210 

- Rename `MerkleTree` → `ActionTree` in `action_tree.rs` and `action.rs`
- Rename `ConsumedResourceWitness::merkle_path` → `cm_merkle_path` to clarify it is the commitment-tree path
- Rename `TestLogicWitness::receive_existence_path` → `action_tree_path` to match the concept it represents
