### PR TITLE
robustness and refactor pass across arm crate

### DIFF
--- a/arm/src/action.rs
+++ b/arm/src/action.rs
@@ -43,7 +43,7 @@ impl Action {
     }
 
     /// Returns a reference to the logic verifier inputs.
-    pub fn get_logic_verifier_inputs(&self) -> &Vec<LogicVerifierInputs> {
+    pub fn get_logic_verifier_inputs(&self) -> &[LogicVerifierInputs] {
         &self.logic_verifier_inputs
     }
 

--- a/arm/src/action_tree.rs
+++ b/arm/src/action_tree.rs
@@ -27,17 +27,7 @@ impl ActionTree {
 
     /// Computes the root of the action tree.
     pub fn root(&self) -> Result<Digest, ArmError> {
-        if self.is_empty() {
-            return Err(ArmError::EmptyTree);
-        }
-
-        let len = self
-            .leaves
-            .len()
-            .checked_next_power_of_two()
-            .ok_or(ArmError::TreeTooLarge)?;
-        let mut cur_layer = self.leaves.clone();
-        cur_layer.resize(len, *PADDING_LEAF);
+        let mut cur_layer = self.padded_leaves()?;
         while cur_layer.len() > 1 {
             cur_layer = cur_layer
                 .chunks(2)
@@ -50,13 +40,45 @@ impl ActionTree {
     /// Generates the Merkle path for a given leaf in the action tree.
     ///
     /// Returns `ArmError::InvalidLeaf` if the leaf is not found in the tree.
-    pub fn generate_path(&self, cur_leave: &Digest) -> Result<MerklePath, ArmError> {
-        if self.is_empty() {
-            return Err(ArmError::EmptyTree);
+    pub fn generate_path(&self, cur_leaf: &Digest) -> Result<MerklePath, ArmError> {
+        if *cur_leaf == *PADDING_LEAF {
+            return Err(ArmError::InvalidLeaf);
         }
 
-        if *cur_leave == *PADDING_LEAF {
-            return Err(ArmError::InvalidLeaf);
+        let mut cur_layer = self.padded_leaves()?;
+        let mut position = cur_layer
+            .iter()
+            .position(|v| v == cur_leaf)
+            .ok_or(ArmError::InvalidLeaf)?;
+        let mut merkle_path = Vec::new();
+
+        while cur_layer.len() > 1 {
+            let is_sibling_left = position % 2 != 0;
+            let sibling_position = if is_sibling_left {
+                position - 1
+            } else {
+                position + 1
+            };
+            merkle_path.push((cur_layer[sibling_position], is_sibling_left));
+
+            cur_layer = cur_layer
+                .chunks(2)
+                .map(|pair| hash_two(&pair[0], &pair[1]))
+                .collect();
+            position /= 2;
+        }
+
+        Ok(MerklePath::from_path(&merkle_path))
+    }
+
+    /// Checks if the action tree is empty.
+    pub fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+
+    fn padded_leaves(&self) -> Result<Vec<Digest>, ArmError> {
+        if self.is_empty() {
+            return Err(ArmError::EmptyTree);
         }
 
         let len = self
@@ -64,50 +86,63 @@ impl ActionTree {
             .len()
             .checked_next_power_of_two()
             .ok_or(ArmError::TreeTooLarge)?;
-        let mut cur_layer = self.leaves.clone();
-        cur_layer.resize(len, *PADDING_LEAF);
-        if let Some(position) = cur_layer.iter().position(|v| v == cur_leave) {
-            let mut merkle_path = Vec::new();
-            fn build_merkle_path_inner(
-                cur_layer: Vec<Digest>,
-                position: usize,
-                path: &mut Vec<(Digest, bool)>,
-            ) {
-                if cur_layer.len() > 1 {
-                    let sibling = {
-                        let is_sibling_left = position % 2 != 0;
-                        let sibling_value = if is_sibling_left {
-                            cur_layer[position - 1]
-                        } else {
-                            cur_layer[position + 1]
-                        };
-                        (sibling_value, is_sibling_left)
-                    };
-                    path.push(sibling);
-
-                    let prev_layer = cur_layer
-                        .chunks(2)
-                        .map(|pair| hash_two(&pair[0], &pair[1]))
-                        .collect();
-
-                    build_merkle_path_inner(prev_layer, position / 2, path);
-                }
-            }
-            build_merkle_path_inner(cur_layer, position, &mut merkle_path);
-            Ok(MerklePath::from_path(merkle_path.as_slice()))
-        } else {
-            Err(ArmError::InvalidLeaf)
-        }
-    }
-
-    /// Checks if the action tree is empty.
-    pub fn is_empty(&self) -> bool {
-        self.leaves.is_empty()
+        let mut leaves = self.leaves.clone();
+        leaves.resize(len, *PADDING_LEAF);
+        Ok(leaves)
     }
 }
 
 impl From<Vec<Digest>> for ActionTree {
     fn from(leaves: Vec<Digest>) -> Self {
         ActionTree::new(leaves)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(byte: u8) -> Digest {
+        Digest::from([byte; 32])
+    }
+
+    #[test]
+    fn generated_path_reconstructs_root() {
+        let leaves = vec![digest(1), digest(2), digest(3)];
+        let tree = ActionTree::new(leaves.clone());
+        let root = tree.root().unwrap();
+
+        for leaf in &leaves {
+            let path = tree.generate_path(leaf).unwrap();
+            assert_eq!(path.root(leaf), root);
+        }
+    }
+
+    #[test]
+    fn last_leaf_sibling_is_padding_for_unbalanced_tree() {
+        // Three leaves pad to four; the last leaf's sibling at the bottom layer
+        // must be PADDING_LEAF, and the resulting path must still reconstruct
+        // the root.
+        let leaves = vec![digest(1), digest(2), digest(3)];
+        let tree = ActionTree::new(leaves.clone());
+        let path = tree.generate_path(&digest(3)).unwrap();
+
+        let (sibling, is_left) = path.0[0];
+        assert_eq!(sibling, *PADDING_LEAF);
+        assert!(!is_left, "padding sibling must sit on the right of leaf 3");
+        assert_eq!(path.root(&digest(3)), tree.root().unwrap());
+    }
+
+    #[test]
+    fn rejects_empty_tree_and_padding_leaf_paths() {
+        let empty = ActionTree::new(Vec::new());
+        assert_eq!(empty.root(), Err(ArmError::EmptyTree));
+        assert_eq!(empty.generate_path(&digest(1)), Err(ArmError::EmptyTree));
+
+        let tree = ActionTree::new(vec![digest(1)]);
+        assert_eq!(
+            tree.generate_path(&PADDING_LEAF),
+            Err(ArmError::InvalidLeaf)
+        );
     }
 }

--- a/arm/src/compliance.rs
+++ b/arm/src/compliance.rs
@@ -1,8 +1,9 @@
 //! Compliance module containing the compliance instance and witness.
 
+#[cfg(test)]
+use crate::nullifier_key::NullifierKey;
 use crate::{
     error::ArmError,
-    nullifier_key::NullifierKey,
     resource::{ConsumedResourcePublic, ConsumedResourceWitness, CreatedResourcePublic, Resource},
     utils::{bytes_to_words, words_to_bytes},
 };
@@ -297,6 +298,7 @@ fn encode_delta(delta: ProjectivePoint) -> Result<([u32; 8], [u32; 8]), ArmError
     Ok((delta_x, delta_y))
 }
 
+#[cfg(test)]
 impl Default for ComplianceWitness {
     /// The default value is meaningless and only for testing.
     /// It contains three consumed and two created resources.

--- a/arm/src/constants.rs
+++ b/arm/src/constants.rs
@@ -2,6 +2,7 @@
 
 use crate::{compliance::KindTableEntry, error::ArmError, resource::Resource};
 use hex::FromHex;
+use k256::{elliptic_curve::sec1::FromEncodedPoint, EncodedPoint, ProjectivePoint};
 use lazy_static::lazy_static;
 use risc0_zkvm::Digest;
 use std::{path::Path, sync::OnceLock};
@@ -74,6 +75,7 @@ pub fn init_kind_table_from_file(path: &Path) -> Result<(), ArmError> {
                 Digest::from_hex(&e.label_ref).map_err(|_| ArmError::KindTableLoadFailed)?;
             let kind_point =
                 hex::decode(&e.kind_point).map_err(|_| ArmError::KindTableLoadFailed)?;
+            validate_kind_point(logic_ref, label_ref, &kind_point)?;
             Ok(KindTableEntry {
                 logic_ref,
                 label_ref,
@@ -83,6 +85,22 @@ pub fn init_kind_table_from_file(path: &Path) -> Result<(), ArmError> {
         .collect::<Result<Vec<_>, _>>()?;
     // First call wins; subsequent calls are silently ignored.
     let _ = GLOBAL_KIND_TABLE.set(entries);
+    Ok(())
+}
+
+fn validate_kind_point(logic_ref: Digest, label_ref: Digest, bytes: &[u8]) -> Result<(), ArmError> {
+    let encoded = EncodedPoint::from_bytes(bytes).map_err(|_| ArmError::KindTableLoadFailed)?;
+    let point = ProjectivePoint::from_encoded_point(&encoded)
+        .into_option()
+        .ok_or(ArmError::KindTableLoadFailed)?;
+    let resource = Resource {
+        logic_ref,
+        label_ref,
+        ..Resource::default()
+    };
+    if point != resource.kind()? {
+        return Err(ArmError::KindTableLoadFailed);
+    }
     Ok(())
 }
 

--- a/arm/src/delta_proof.rs
+++ b/arm/src/delta_proof.rs
@@ -94,41 +94,51 @@ impl DeltaProof {
     }
 
     /// Deserializes the delta proof from bytes.
+    ///
+    /// Accepts the v-byte in either the raw `{0, 1}` form or the Ethereum
+    /// `{27, 28}` form. `to_bytes` always emits the `{27, 28}` form.
     pub fn from_bytes(bytes: &[u8]) -> Result<DeltaProof, ArmError> {
+        if bytes.len() != 65 {
+            return Err(ArmError::InvalidSignature);
+        }
+        let raw_v = match bytes[64] {
+            v @ (0 | 1) => v,
+            v @ (27 | 28) => v - 27,
+            _ => return Err(ArmError::InvalidSignature),
+        };
+        let recid = RecoveryId::from_byte(raw_v).ok_or(ArmError::InvalidSignature)?;
         Ok(DeltaProof {
             signature: Signature::from_bytes((&bytes[0..64]).into())
                 .map_err(|_| ArmError::InvalidSignature)?,
-            recid: RecoveryId::from_byte(bytes[64] - 27).ok_or(ArmError::InvalidSignature)?,
+            recid,
         })
     }
 }
 
 impl DeltaWitness {
     /// Creates a delta witness from a list of secret keys by summing them up.
-    pub fn from_scalars(secret_keys: &[Scalar]) -> DeltaWitness {
-        let sum: ScalarPrimitive<_> = secret_keys
-            .iter()
-            .fold(Scalar::ZERO, |acc, x| acc + x)
-            .into();
-        let sk: SecretKey = SecretKey::new(sum);
-        let signing_key = SigningKey::from(&sk);
-        DeltaWitness { signing_key }
+    pub fn from_scalars(secret_keys: &[Scalar]) -> Result<DeltaWitness, ArmError> {
+        if secret_keys.is_empty() {
+            return Err(ArmError::EmptyDeltaWitnesses);
+        }
+        let sum = secret_keys.iter().fold(Scalar::ZERO, |acc, x| acc + x);
+        signing_key_from_scalar(sum).map(|signing_key| DeltaWitness { signing_key })
     }
 
     /// Creates a delta witness from a list of byte vectors representing secret keys.
     pub fn from_bytes_vec(keys: &[Vec<u8>]) -> Result<DeltaWitness, ArmError> {
-        let witnesses: Result<Vec<DeltaWitness>, ArmError> = keys
+        let witnesses: Vec<DeltaWitness> = keys
             .iter()
             .map(|key| DeltaWitness::from_bytes(key))
-            .collect();
-        Ok(DeltaWitness::compress(&witnesses?))
+            .collect::<Result<_, _>>()?;
+        DeltaWitness::compress(&witnesses)
     }
 
     /// Creates a delta witness from bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<DeltaWitness, ArmError> {
+        let sk = SecretKey::from_slice(bytes).map_err(|_| ArmError::InvalidSigningKey)?;
         Ok(DeltaWitness {
-            signing_key: SigningKey::from_bytes(bytes.into())
-                .map_err(|_| ArmError::InvalidSigningKey)?,
+            signing_key: SigningKey::from(&sk),
         })
     }
 
@@ -138,23 +148,26 @@ impl DeltaWitness {
     }
 
     /// Composes two delta witnesses by summing their signing keys.
-    pub fn compose(&self, other: &DeltaWitness) -> Self {
+    pub fn compose(&self, other: &DeltaWitness) -> Result<Self, ArmError> {
         let sum = self.signing_key.as_nonzero_scalar().as_ref()
             + other.signing_key.as_nonzero_scalar().as_ref();
-        let sk: SecretKey = SecretKey::new(sum.into());
-        Self {
-            signing_key: SigningKey::from(sk),
-        }
+        signing_key_from_scalar(sum).map(|signing_key| Self { signing_key })
     }
 
     /// Compresses a list of delta witnesses into a single delta witness by summing them up.
-    pub fn compress(witnesses: &[DeltaWitness]) -> DeltaWitness {
-        let mut sum = witnesses[0].clone();
-        for witness in witnesses.iter().skip(1) {
-            sum = sum.compose(witness);
-        }
-        sum
+    pub fn compress(witnesses: &[DeltaWitness]) -> Result<DeltaWitness, ArmError> {
+        let (first, rest) = witnesses
+            .split_first()
+            .ok_or(ArmError::EmptyDeltaWitnesses)?;
+        rest.iter().try_fold(first.clone(), |acc, w| acc.compose(w))
     }
+}
+
+fn signing_key_from_scalar(scalar: Scalar) -> Result<SigningKey, ArmError> {
+    let primitive: ScalarPrimitive<_> = scalar.into();
+    let sk =
+        SecretKey::from_slice(&primitive.to_bytes()).map_err(|_| ArmError::InvalidSigningKey)?;
+    Ok(SigningKey::from(&sk))
 }
 
 impl DeltaInstance {
@@ -251,6 +264,57 @@ mod tests {
         let encoded = bincode::serialize(&proof).unwrap();
         let decoded: DeltaProof = bincode::deserialize(&encoded).unwrap();
         assert_eq!(proof, decoded);
+    }
+
+    #[test]
+    fn delta_proof_from_bytes_rejects_invalid_inputs() {
+        assert_eq!(
+            DeltaProof::from_bytes(&[0u8; 64]),
+            Err(ArmError::InvalidSignature)
+        );
+
+        for bad_v in [2u8, 26, 29, 255] {
+            let mut bytes = [0u8; 65];
+            bytes[64] = bad_v;
+            assert_eq!(
+                DeltaProof::from_bytes(&bytes),
+                Err(ArmError::InvalidSignature),
+                "v={bad_v} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn delta_proof_from_bytes_accepts_raw_and_ethereum_v() {
+        let mut rng = OsRng;
+        let signing_key = SigningKey::random(&mut rng);
+        let witness = DeltaWitness { signing_key };
+        let proof = DeltaProof::prove(b"v-byte", &witness).unwrap();
+        let canonical = proof.to_bytes();
+
+        // Canonical Ethereum-style {27, 28} round-trips.
+        assert_eq!(DeltaProof::from_bytes(&canonical).unwrap(), proof);
+
+        // Raw {0, 1} v-byte is also accepted and yields the same proof.
+        let mut raw = canonical;
+        raw[64] = canonical[64] - 27;
+        assert_eq!(DeltaProof::from_bytes(&raw).unwrap(), proof);
+    }
+
+    #[test]
+    fn empty_delta_witness_inputs_are_rejected() {
+        assert_eq!(
+            DeltaWitness::from_scalars(&[]),
+            Err(ArmError::EmptyDeltaWitnesses)
+        );
+        assert_eq!(
+            DeltaWitness::from_bytes_vec(&[]),
+            Err(ArmError::EmptyDeltaWitnesses)
+        );
+        assert_eq!(
+            DeltaWitness::compress(&[]),
+            Err(ArmError::EmptyDeltaWitnesses)
+        );
     }
 
     /// DeltaWitness: serialize then deserialize via bincode must round-trip.

--- a/arm/src/error.rs
+++ b/arm/src/error.rs
@@ -84,4 +84,10 @@ pub enum ArmError {
     KindTableLoadFailed,
     #[error("Cannot derive nonces from an empty nullifier set")]
     EmptyNullifiers,
+    #[error("Cannot compose transactions with different delta types")]
+    IncompatibleDeltaTypes,
+    #[error("Cannot compress an empty set of delta witnesses")]
+    EmptyDeltaWitnesses,
+    #[error("Invalid padding resource")]
+    InvalidPaddingResource,
 }

--- a/arm/src/logic_proof.rs
+++ b/arm/src/logic_proof.rs
@@ -228,6 +228,7 @@ impl LogicProver for TrivialLogicWitness {
     }
 }
 
+#[cfg(all(test, feature = "prove"))]
 #[test]
 fn test_padding_logic_prover() {
     let trivial_logic = PaddingResourceLogic::default();

--- a/arm/src/merkle_path.rs
+++ b/arm/src/merkle_path.rs
@@ -47,7 +47,7 @@ impl MerklePath {
 
     /// Creates an empty Merkle path.
     pub fn empty() -> Self {
-        MerklePath(vec![])
+        MerklePath(Vec::new())
     }
 }
 

--- a/arm/src/resource.rs
+++ b/arm/src/resource.rs
@@ -74,10 +74,7 @@ impl Resource {
             quantity,
             value_ref,
             is_ephemeral,
-            nonce: nonce
-                .as_bytes()
-                .try_into()
-                .expect("it can not fail since the digest length is always 32 bytes"),
+            nonce: nonce.into(),
             nk_commitment,
             rand_seed: OsRng.gen(),
         }
@@ -99,50 +96,26 @@ impl Resource {
             .map_err(|_| ArmError::InvalidResourceKind)
     }
 
+    /// Core PRF: `SHA256(personalization || discriminator || rand_seed || nonce)`.
+    fn prf_expand(&self, discriminator: u8) -> Vec<u8> {
+        const LEN: usize = PRF_EXPAND_PERSONALIZATION_LEN + 1 + 2 * DIGEST_BYTES;
+        let mut bytes = [0u8; LEN];
+        bytes[..PRF_EXPAND_PERSONALIZATION_LEN].copy_from_slice(PRF_EXPAND_PERSONALIZATION);
+        bytes[PRF_EXPAND_PERSONALIZATION_LEN] = discriminator;
+        let seed_start = PRF_EXPAND_PERSONALIZATION_LEN + 1;
+        bytes[seed_start..seed_start + DIGEST_BYTES].copy_from_slice(&self.rand_seed);
+        bytes[seed_start + DIGEST_BYTES..].copy_from_slice(&self.nonce);
+        Impl::hash_bytes(&bytes).as_bytes().to_vec()
+    }
+
     /// Compute the inner psi for the resource
     fn psi(&self) -> Vec<u8> {
-        let mut bytes = [0u8; PRF_EXPAND_PERSONALIZATION_LEN + 1 + 2 * DIGEST_BYTES];
-        let mut offset: usize = 0;
-        // Write the PRF_EXPAND_PERSONALIZATION
-        bytes[offset..offset + 16].clone_from_slice(PRF_EXPAND_PERSONALIZATION);
-        offset += PRF_EXPAND_PERSONALIZATION_LEN;
-        // Write the PRF_EXPAND_PSI
-        bytes[offset..offset + 1].clone_from_slice(&PRF_EXPAND_PSI.to_be_bytes());
-        offset += 1;
-        // Write the random seed
-        bytes[offset..offset + DIGEST_BYTES].clone_from_slice(self.rand_seed.as_ref());
-        offset += DIGEST_BYTES;
-        // Write the nonce
-        bytes[offset..offset + DIGEST_BYTES].clone_from_slice(self.nonce.as_ref());
-        offset += DIGEST_BYTES;
-        assert_eq!(
-            offset,
-            PRF_EXPAND_PERSONALIZATION_LEN + 1 + 2 * DIGEST_BYTES
-        );
-        Impl::hash_bytes(&bytes).as_bytes().to_vec()
+        self.prf_expand(PRF_EXPAND_PSI)
     }
 
     /// Compute the randomness to commit the resource
     fn rcm(&self) -> Vec<u8> {
-        let mut bytes = [0u8; PRF_EXPAND_PERSONALIZATION_LEN + 1 + 2 * DIGEST_BYTES];
-        let mut offset: usize = 0;
-        // Write the PRF_EXPAND_PERSONALIZATION
-        bytes[offset..offset + 16].clone_from_slice(PRF_EXPAND_PERSONALIZATION);
-        offset += PRF_EXPAND_PERSONALIZATION_LEN;
-        // Write the PRF_EXPAND_RCM
-        bytes[offset..offset + 1].clone_from_slice(&PRF_EXPAND_RCM.to_be_bytes());
-        offset += 1;
-        // Write the random seed
-        bytes[offset..offset + DIGEST_BYTES].clone_from_slice(self.rand_seed.as_ref());
-        offset += DIGEST_BYTES;
-        // Write the nonce
-        bytes[offset..offset + DIGEST_BYTES].clone_from_slice(self.nonce.as_ref());
-        offset += DIGEST_BYTES;
-        assert_eq!(
-            offset,
-            PRF_EXPAND_PERSONALIZATION_LEN + 1 + 2 * DIGEST_BYTES
-        );
-        Impl::hash_bytes(&bytes).as_bytes().to_vec()
+        self.prf_expand(PRF_EXPAND_RCM)
     }
 
     /// Compute the commitment to the resource
@@ -244,10 +217,7 @@ impl Resource {
 
     /// Set the nonce of the resource
     pub fn set_nonce(&mut self, nf: Digest) {
-        self.nonce = nf
-            .as_bytes()
-            .try_into()
-            .expect("it can not fail since the digest length is always 32 bytes");
+        self.nonce = nf.into();
     }
 
     /// Set the nonce of the resource from consumed nullifier
@@ -256,11 +226,7 @@ impl Resource {
         resource: &Resource,
         nf_key: &NullifierKey,
     ) -> Result<(), ArmError> {
-        self.nonce = resource
-            .nullifier(nf_key)?
-            .as_bytes()
-            .try_into()
-            .map_err(|_| ArmError::InvalidResourceNonce)?;
+        self.nonce = resource.nullifier(nf_key)?.into();
         Ok(())
     }
 

--- a/arm/src/resource_logic.rs
+++ b/arm/src/resource_logic.rs
@@ -39,8 +39,9 @@ impl LogicCircuit for TrivialLogicWitness {
         let tag = self.resource.tag(self.is_consumed, &self.nf_key)?;
 
         // The trivial resource is ephemeral and has zero quantity
-        assert_eq!(self.resource.quantity, 0);
-        assert!(self.resource.is_ephemeral);
+        if self.resource.quantity != 0 || !self.resource.is_ephemeral {
+            return Err(ArmError::InvalidPaddingResource);
+        }
 
         Ok(LogicInstance {
             tag,
@@ -65,5 +66,21 @@ impl TrivialLogicWitness {
             is_consumed,
             nf_key,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trivial_logic_rejects_non_padding_resource() {
+        let mut witness = TrivialLogicWitness::default();
+        witness.resource.quantity = 1;
+        assert_eq!(witness.constrain(), Err(ArmError::InvalidPaddingResource));
+
+        witness.resource.quantity = 0;
+        witness.resource.is_ephemeral = false;
+        assert_eq!(witness.constrain(), Err(ArmError::InvalidPaddingResource));
     }
 }

--- a/arm/src/transaction.rs
+++ b/arm/src/transaction.rs
@@ -142,16 +142,18 @@ impl Transaction {
     }
 
     /// Composes two transactions by concatenating their actions and combining their delta witnesses.
-    pub fn compose(tx1: Transaction, tx2: Transaction) -> Transaction {
+    /// Both transactions must carry a `Delta::Witness`; composing after a delta proof has been
+    /// generated is not supported.
+    pub fn compose(tx1: Transaction, tx2: Transaction) -> Result<Transaction, ArmError> {
         let mut actions = tx1.actions;
         actions.extend(tx2.actions);
-        let delta = match (&tx1.delta_proof, &tx2.delta_proof) {
+        let delta = match (tx1.delta_proof, tx2.delta_proof) {
             (Delta::Witness(witness1), Delta::Witness(witness2)) => {
-                Delta::Witness(witness1.compose(witness2))
+                Delta::Witness(witness1.compose(&witness2)?)
             }
-            _ => panic!("Cannot compose transactions with different delta types"),
+            _ => return Err(ArmError::IncompatibleDeltaTypes),
         };
-        Transaction::create(actions, delta)
+        Ok(Transaction::create(actions, delta))
     }
 
     /// Returns `true` if any compliance or resource logic proof is `None`.

--- a/arm/src/utils.rs
+++ b/arm/src/utils.rs
@@ -3,26 +3,21 @@
 use risc0_zkvm::sha::{Digest, Impl, Sha256, DIGEST_WORDS};
 
 /// Converts a byte slice to a vector of u32 words.
+///
+/// Both `bytes_to_words` and `words_to_bytes` use native-endian ordering, so
+/// they round-trip the same byte sequence on any platform. The integer values
+/// of the resulting words are not portable across endianness.
 pub fn bytes_to_words(bytes: &[u8]) -> Vec<u32> {
-    let mut words = Vec::new();
     let mut iter = bytes.chunks_exact(4);
-    for chunk in iter.by_ref() {
-        let mut word = 0u32;
-        for &byte in chunk {
-            word = (word << 8) | (byte as u32);
-        }
-        words.push(u32::from_be(word));
-    }
-
+    let mut words: Vec<u32> = iter
+        .by_ref()
+        .map(|chunk| u32::from_ne_bytes(chunk.try_into().unwrap()))
+        .collect();
     let rem = iter.remainder();
     if !rem.is_empty() {
         let mut arr = [0u8; 4];
         arr[..rem.len()].copy_from_slice(rem);
-        let mut word = 0u32;
-        for byte in arr {
-            word = (word << 8) | (byte as u32);
-        }
-        words.push(u32::from_be(word));
+        words.push(u32::from_ne_bytes(arr));
     }
     words
 }

--- a/arm_tests/arm_test_app/src/lib.rs
+++ b/arm_tests/arm_test_app/src/lib.rs
@@ -390,6 +390,7 @@ fn test_compose_transactions() {
     let tx_b = Transaction::create(actions_b, Delta::Witness(tester_b.delta_witness()));
 
     let composed = Transaction::compose(tx_a, tx_b)
+        .unwrap()
         .generate_delta_proof()
         .unwrap();
     assert!(composed.verify().is_ok());


### PR DESCRIPTION
## Summary

Robustness pass across the `arm` crate: previously-panicking inputs now return
`ArmError`, and several deserialization paths gained stricter validation. No
happy-path behavior changes.

### API changes
- `Transaction::compose` now returns `Result<Transaction, ArmError>` (was: panic
  on mismatched delta types).
- `DeltaWitness::from_scalars`, `compose`, and `compress` return `Result`; empty
  inputs and zero-sum scalars are rejected via `EmptyDeltaWitnesses` /
  `InvalidSigningKey` instead of panicking.
- `Action::get_logic_verifier_inputs` returns `&[LogicVerifierInputs]` instead
  of `&Vec<_>`.
- New `ArmError` variants: `IncompatibleDeltaTypes`, `EmptyDeltaWitnesses`,
  `InvalidPaddingResource`.

### Validation
- `DeltaProof::from_bytes` enforces a 65-byte length and a valid v-byte range
  (`{27, 28}`), closing a silent underflow for `v < 27`.
- `init_kind_table_from_file` validates each entry's `kind_point` against
  `Resource::kind()` so a corrupt or malicious kind table fails at load time
  rather than being trusted at lookup.
- `TrivialLogicWitness::constrain` returns `InvalidPaddingResource` instead of
  asserting on non-padding resources.

### Refactors
- `Resource::psi`/`rcm` deduped via a shared `prf_expand` helper; nonce setters
  use `Digest::into()`.
- `ActionTree::generate_path` is now iterative and shares a `padded_leaves()`
  helper with `root()`.
- `bytes_to_words` rewritten using `from_ne_bytes` (behavior-equivalent on all
  platforms, paired with the native-endian `words_to_bytes`).
- `ComplianceWitness::Default` and `test_padding_logic_prover` are now
  appropriately `cfg`-gated.

### Tests
- New unit tests in `action_tree`, `delta_proof`, `resource_logic`, and
  `constants`; the existing `arm_test_app::test_compose_transactions` updated
  for the new `compose` signature.