### PR TITLE
Ref the self for transaction verification

### DIFF
--- a/arm/src/transaction.rs
+++ b/arm/src/transaction.rs
@@ -74,7 +74,7 @@ impl Transaction {
     }
 
     /// Verifies all the proofs and corresponding checks in the transaction.
-    pub fn verify(self) -> Result<(), ArmError> {
+    pub fn verify(&self) -> Result<(), ArmError> {
         match &self.delta_proof {
             Delta::Proof(ref proof) => {
                 let msg = self.get_delta_msg()?;
@@ -94,7 +94,7 @@ impl Transaction {
                     self.verify_aggregation()?;
                 } else {
                     // Try verifying individually.
-                    for action in self.actions {
+                    for action in &self.actions {
                         action.verify()?;
                     }
                 }


### PR DESCRIPTION
No need to consume the self