### PR TITLE
enforce kind_table_commitment consistency on transaction verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,6 @@ dependencies = [
  "anoma-rm-risc0",
  "anoma-rm-risc0-test-witness",
  "hex",
- "k256",
  "lazy_static",
  "serde",
 ]

--- a/arm/src/constants.rs
+++ b/arm/src/constants.rs
@@ -4,7 +4,10 @@ use crate::{compliance::KindTableEntry, error::ArmError, resource::Resource};
 use hex::FromHex;
 use k256::{elliptic_curve::sec1::FromEncodedPoint, EncodedPoint, ProjectivePoint};
 use lazy_static::lazy_static;
-use risc0_zkvm::Digest;
+use risc0_zkvm::{
+    sha::{Impl as ShaImpl, Sha256},
+    Digest,
+};
 use std::{path::Path, sync::OnceLock};
 
 /// Compliance proving key / compliance guest ELF binary
@@ -33,8 +36,8 @@ lazy_static! {
     pub static ref BATCH_AGGREGATION_VK: Digest = Digest::from_hex("67382671772a832be0ece0b7ce52019f015a364788559a12328c15850e721952").unwrap();
 }
 
-/// Global kind table, loaded once from a JSON file.
-static GLOBAL_KIND_TABLE: OnceLock<Vec<KindTableEntry>> = OnceLock::new();
+/// Global kind table and its SHA-256 commitment, loaded once from a JSON file.
+static GLOBAL_KIND_TABLE: OnceLock<(Vec<KindTableEntry>, Digest)> = OnceLock::new();
 
 /// JSON-serializable representation of a kind table entry.
 /// `logic_ref`, `label_ref`, and `kind_point` are lowercase hex strings.
@@ -84,7 +87,8 @@ pub fn init_kind_table_from_file(path: &Path) -> Result<(), ArmError> {
         })
         .collect::<Result<Vec<_>, _>>()?;
     // First call wins; subsequent calls are silently ignored.
-    let _ = GLOBAL_KIND_TABLE.set(entries);
+    let hash = hash_kind_table_entries(&entries);
+    let _ = GLOBAL_KIND_TABLE.set((entries, hash));
     Ok(())
 }
 
@@ -107,7 +111,27 @@ fn validate_kind_point(logic_ref: Digest, label_ref: Digest, bytes: &[u8]) -> Re
 /// Returns the currently loaded global kind table (empty slice if not yet
 /// initialised).
 pub fn global_kind_table() -> &'static [KindTableEntry] {
-    GLOBAL_KIND_TABLE.get().map_or(&[], Vec::as_slice)
+    GLOBAL_KIND_TABLE.get().map_or(&[], |(entries, _)| entries)
+}
+
+/// Returns the SHA-256 commitment to the global kind table, or `None` if the
+/// table has not been initialised yet.
+///
+/// The commitment is computed using the same algorithm as
+/// `ComplianceWitness::hash_kind_table`: SHA-256 over the concatenated
+/// `(logic_ref ‖ label_ref ‖ kind_point)` bytes of every entry in order.
+pub fn global_kind_table_hash() -> Option<&'static Digest> {
+    GLOBAL_KIND_TABLE.get().map(|(_, hash)| hash)
+}
+
+fn hash_kind_table_entries(entries: &[KindTableEntry]) -> Digest {
+    let mut bytes = Vec::new();
+    for entry in entries {
+        bytes.extend_from_slice(entry.logic_ref.as_bytes());
+        bytes.extend_from_slice(entry.label_ref.as_bytes());
+        bytes.extend_from_slice(&entry.kind_point);
+    }
+    *ShaImpl::hash_bytes(&bytes)
 }
 
 /// Looks up `resource` in `table` and returns its pre-computed kind point, or

--- a/arm/src/error.rs
+++ b/arm/src/error.rs
@@ -72,6 +72,12 @@ pub enum ArmError {
     InvalidNullifierCommitment,
     #[error("Nullifier duplication detected")]
     NullifierDuplication,
+    #[error("kind_table_commitment mismatch across compliance units")]
+    KindTableCommitmentMismatch,
+    #[error("kind_table_commitment does not match the loaded global kind table")]
+    KindTableGlobalMismatch,
+    #[error("global kind table not loaded")]
+    KindTableNotLoaded,
     #[error("Empty tree")]
     EmptyTree,
     #[error("Invalid shared secret")]

--- a/arm/src/proving_system.rs
+++ b/arm/src/proving_system.rs
@@ -1,13 +1,11 @@
 //! Proving system interface for generating and verifying proofs.
 
-use crate::error::ArmError;
+use crate::{error::ArmError, utils::words_to_bytes};
 use risc0_zkvm::{sha::Digest, InnerReceipt, Receipt};
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 
 #[cfg(feature = "prove")]
 use risc0_zkvm::{default_prover, ExecutorEnv, ProverOpts, VerifierContext};
-#[cfg(feature = "prove")]
-use serde::Serialize;
 
 /// Types of proofs supported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,6 +39,13 @@ pub fn verify(verifying_key: &Digest, instance: &[u8], proof: &[u8]) -> Result<(
     receipt.verify(*verifying_key).map_err(|err| {
         ArmError::ProofVerificationFailed(format!("Proof verification failed: {}", err))
     })
+}
+
+/// Serializes an instance into journal bytes (the inverse of `journal_to_instance`).
+pub fn instance_to_journal<T: Serialize>(instance: &T) -> Result<Vec<u8>, ArmError> {
+    let words =
+        risc0_zkvm::serde::to_vec(instance).map_err(|_| ArmError::InstanceSerializationFailed)?;
+    Ok(words_to_bytes(&words).to_vec())
 }
 
 /// Converts a serialized journal into an instance of the specified type.

--- a/arm/src/transaction.rs
+++ b/arm/src/transaction.rs
@@ -1,5 +1,6 @@
 //! Transaction structure and associated methods.
 
+use crate::constants::global_kind_table_hash;
 #[cfg(feature = "aggregation")]
 use crate::{
     constants::{BATCH_AGGREGATION_PK, BATCH_AGGREGATION_VK, COMPLIANCE_VK},
@@ -83,6 +84,7 @@ impl Transaction {
 
                 // Check for nullifier duplication across all compliance units
                 self.nf_duplication_check()?;
+                self.kind_table_commitment_check()?;
 
                 if self.aggregation_proof.is_some() {
                     #[cfg(not(feature = "aggregation"))]
@@ -102,6 +104,27 @@ impl Transaction {
             }
             Delta::Witness(_) => Err(ArmError::ExpectedDeltaProof),
         }
+    }
+
+    /// Checks that all compliance units in the transaction commit to the same kind table,
+    /// and that the commitment matches the loaded global kind table.
+    pub fn kind_table_commitment_check(&self) -> Result<(), ArmError> {
+        let mut iter = self.actions.iter();
+        let Some(first) = iter.next() else {
+            return Ok(());
+        };
+        let expected = first.compliance_unit.get_instance()?.kind_table_commitment;
+        for action in iter {
+            let commitment = action.compliance_unit.get_instance()?.kind_table_commitment;
+            if commitment != expected {
+                return Err(ArmError::KindTableCommitmentMismatch);
+            }
+        }
+        let global_hash = global_kind_table_hash().ok_or(ArmError::KindTableNotLoaded)?;
+        if expected != *global_hash {
+            return Err(ArmError::KindTableGlobalMismatch);
+        }
+        Ok(())
     }
 
     /// Inner check for nullifier duplication across all compliance units

--- a/arm_tests/arm_test_app/Cargo.toml
+++ b/arm_tests/arm_test_app/Cargo.toml
@@ -12,14 +12,6 @@ anoma-rm-risc0-test-witness = { path = "../arm_test_witness" }
 serde = { version = "1.0.197", default-features = false }
 hex = "0.4"
 lazy_static = "1.5.0"
-k256 = { version = "=0.13.3", features = [
-  "arithmetic",
-  "serde",
-  "expose-field",
-  "std",
-  "ecdsa",
-  "hash2curve",
-], default-features = false }
 
 [features]
 default = []

--- a/arm_tests/arm_test_app/src/lib.rs
+++ b/arm_tests/arm_test_app/src/lib.rs
@@ -17,6 +17,11 @@ use anoma_rm_risc0::{
     transaction::{Delta, Transaction},
     Digest,
 };
+#[cfg(test)]
+use anoma_rm_risc0::{
+    compliance::ComplianceInstance,
+    proving_system::{instance_to_journal, journal_to_instance},
+};
 use anoma_rm_risc0_test_witness::TestLogicWitness;
 use hex::FromHex;
 use lazy_static::lazy_static;
@@ -240,6 +245,19 @@ fn init_test_kind_table() {
     init_kind_table_from_file(&path).expect("Failed to load kind_table.json");
 }
 
+#[cfg(test)]
+fn encode_compliance_instance(instance: &ComplianceInstance) -> Vec<u8> {
+    instance_to_journal(instance).expect("instance must serialize")
+}
+
+#[cfg(test)]
+fn set_action_kind_table_commitment(action: &mut Action, commitment: Digest) {
+    let mut instance: ComplianceInstance =
+        journal_to_instance(&action.compliance_unit.instance).expect("instance must decode");
+    instance.kind_table_commitment = commitment;
+    action.compliance_unit.instance = encode_compliance_instance(&instance);
+}
+
 /// A 32-byte nonce that varies per index. The exact bytes don't matter as long
 /// as nonces are distinct across consumed resources within a CU.
 fn nonce_from_index(index: u32) -> [u8; 32] {
@@ -318,6 +336,65 @@ fn test_nullifier_duplication_check() {
     tx.actions[1] = tx.actions[0].clone();
 
     assert!(tx.nf_duplication_check().is_err());
+}
+
+/// All actions carry the global kind-table commitment — the check must pass.
+#[test]
+fn test_kind_table_commitment_check_accepts_global_commitment() {
+    let tx = Tester::default()
+        .generate_test_transaction(&[(1, 1)])
+        .unwrap();
+    assert!(tx.kind_table_commitment_check().is_ok());
+}
+
+/// One action has a different commitment from the other — cross-action
+/// consistency check must fire before the global check.
+#[test]
+fn test_kind_table_commitment_check_rejects_mismatched_actions() {
+    let mut tx = Tester::default()
+        .generate_test_transaction(&[(1, 1), (1, 1)])
+        .unwrap();
+
+    set_action_kind_table_commitment(&mut tx.actions[1], Digest::from([0xA5; 32]));
+
+    assert!(matches!(
+        tx.kind_table_commitment_check(),
+        Err(ArmError::KindTableCommitmentMismatch)
+    ));
+}
+
+/// Both actions agree on a fake commitment — cross-action check passes but the
+/// global check must catch the mismatch.
+#[test]
+fn test_kind_table_commitment_check_rejects_consistent_non_global() {
+    let mut tx = Tester::default()
+        .generate_test_transaction(&[(1, 1), (1, 1)])
+        .unwrap();
+
+    let fake = Digest::from([0x5A; 32]);
+    set_action_kind_table_commitment(&mut tx.actions[0], fake);
+    set_action_kind_table_commitment(&mut tx.actions[1], fake);
+
+    assert!(matches!(
+        tx.kind_table_commitment_check(),
+        Err(ArmError::KindTableGlobalMismatch)
+    ));
+}
+
+/// Single action with a non-global commitment — trivially passes cross-action
+/// check, global check must reject.
+#[test]
+fn test_kind_table_commitment_check_rejects_global_mismatch() {
+    let mut tx = Tester::default()
+        .generate_test_transaction(&[(1, 1)])
+        .unwrap();
+
+    set_action_kind_table_commitment(&mut tx.actions[0], Digest::from([0x5A; 32]));
+
+    assert!(matches!(
+        tx.kind_table_commitment_check(),
+        Err(ArmError::KindTableGlobalMismatch)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
The compliance circuit commits a kind_table_commitment — a SHA-256 hash of the kind lookup table — as part of each proof's journal. This cryptographically binds each individual compliance proof to the table it used. However, nothing previously cross-checked this value across actions within a transaction, or verified it against the expected global table. A prover could use a different kind table in each compliance unit and it would pass undetected through both the host verifier and the aggregation circuit.