### PR TITLE
refactor(delta): bundle message into DeltaInstance; use action tree root

### DIFF
--- a/arm/src/action.rs
+++ b/arm/src/action.rs
@@ -112,16 +112,15 @@ impl Action {
         self.compliance_unit.delta()
     }
 
-    /// Constructs the delta message by concatenating the delta messages
-    /// of each compliance unit.
+    /// Returns this action's contribution to the delta message: its action tree root.
     pub fn get_delta_msg(&self) -> Result<Vec<u8>, ArmError> {
-        let mut msg = Vec::new();
-        if let Ok(instance) = self.compliance_unit.get_instance() {
-            msg.extend_from_slice(&instance.delta_msg());
-        } else {
-            return Err(ArmError::InvalidComplianceInstance);
-        }
-        Ok(msg)
+        let instance = self
+            .compliance_unit
+            .get_instance()
+            .map_err(|_| ArmError::InvalidComplianceInstance)?;
+        let tags: Vec<Digest> = instance.tags().collect();
+        let root = Self::construct_action_tree(&tags).root()?;
+        Ok(root.as_bytes().to_vec())
     }
 
     /// Constructs the action tree from the passed tags.

--- a/arm/src/action.rs
+++ b/arm/src/action.rs
@@ -57,11 +57,12 @@ impl Action {
         let compliance_instance = self.compliance_unit.get_instance()?;
 
         let tags: Vec<Digest> = compliance_instance.tags().collect();
-        let action_tree_root = Self::construct_action_tree(&tags).root()?;
 
         if tags.len() != self.logic_verifier_inputs.len() {
             return Err(ArmError::TagNotFound);
         }
+
+        let action_tree_root = ActionTree::new(tags).root()?;
 
         let entries = compliance_instance
             .consumed_publics
@@ -119,18 +120,7 @@ impl Action {
             .get_instance()
             .map_err(|_| ArmError::InvalidComplianceInstance)?;
         let tags: Vec<Digest> = instance.tags().collect();
-        let root = Self::construct_action_tree(&tags).root()?;
+        let root = ActionTree::new(tags).root()?;
         Ok(root.as_bytes().to_vec())
-    }
-
-    /// Constructs the action tree from the passed tags.
-    ///
-    /// The caller MUST pass tags in the canonical order produced by
-    /// [`ComplianceInstance::tags`] — consumed nullifiers first, then created
-    /// commitments. Any other ordering (e.g. sorting) will produce a different
-    /// root and the resulting action's logic proofs will fail to verify with
-    /// a generic proof-verification error.
-    pub fn construct_action_tree(tags: &[Digest]) -> ActionTree {
-        ActionTree::new(tags.to_vec())
     }
 }

--- a/arm/src/delta_proof.rs
+++ b/arm/src/delta_proof.rs
@@ -26,11 +26,13 @@ pub struct DeltaWitness {
     pub signing_key: SigningKey,
 }
 
-/// The delta instance contains the verifying key used to verify the delta proof.
+/// The delta instance contains the verifying key and the message used to verify the delta proof.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeltaInstance {
     /// The verifying key.
     pub verifying_key: VerifyingKey,
+    /// The message that was signed.
+    pub message: Vec<u8>,
 }
 
 impl DeltaProof {
@@ -54,12 +56,8 @@ impl DeltaProof {
         Ok(DeltaProof { signature, recid })
     }
 
-    /// Verifies the delta proof against the given message and instance.
-    pub fn verify(
-        message: &[u8],
-        proof: &DeltaProof,
-        instance: DeltaInstance,
-    ) -> Result<(), ArmError> {
+    /// Verifies the delta proof against the instance (which carries the message).
+    pub fn verify(proof: &DeltaProof, instance: DeltaInstance) -> Result<(), ArmError> {
         // handle recid
         if proof.recid.to_byte() > 1 {
             return Err(ArmError::InvalidDeltaProof);
@@ -74,7 +72,7 @@ impl DeltaProof {
 
         // Hash the message using Keccak256
         let mut digest = Keccak256::new();
-        digest.update(message);
+        digest.update(&instance.message);
 
         // Verify the signature
         let vk = VerifyingKey::recover_from_digest(digest, &proof.signature, proof.recid)
@@ -171,14 +169,17 @@ fn signing_key_from_scalar(scalar: Scalar) -> Result<SigningKey, ArmError> {
 }
 
 impl DeltaInstance {
-    /// Creates a delta instance from a list of projective points by summing them up.
-    pub fn from_deltas(deltas: &[ProjectivePoint]) -> Result<DeltaInstance, ArmError> {
+    /// Creates a delta instance from a list of projective points and the signed message.
+    pub fn new(deltas: &[ProjectivePoint], message: Vec<u8>) -> Result<DeltaInstance, ArmError> {
         let sum = deltas
             .iter()
             .fold(ProjectivePoint::IDENTITY, |acc, x| acc + x);
         let pk = PublicKey::from_affine(sum.to_affine()).map_err(|_| ArmError::InvalidPublicKey)?;
         let vk = VerifyingKey::from(&pk);
-        Ok(DeltaInstance { verifying_key: vk })
+        Ok(DeltaInstance {
+            verifying_key: vk,
+            message,
+        })
     }
 }
 
@@ -245,12 +246,15 @@ mod tests {
         let signing_key = SigningKey::random(&mut rng);
         let verifying_key = VerifyingKey::from(&signing_key);
 
-        let message = b"Hello, world!";
+        let message = b"Hello, world!".to_vec();
         let witness = DeltaWitness { signing_key };
-        let proof = DeltaProof::prove(message, &witness).unwrap();
-        let instance = DeltaInstance { verifying_key };
+        let proof = DeltaProof::prove(&message, &witness).unwrap();
+        let instance = DeltaInstance {
+            verifying_key,
+            message,
+        };
 
-        DeltaProof::verify(message, &proof, instance).unwrap();
+        DeltaProof::verify(&proof, instance).unwrap();
     }
 
     /// DeltaProof: serialize then deserialize via bincode must round-trip.

--- a/arm/src/delta_proof.rs
+++ b/arm/src/delta_proof.rs
@@ -57,7 +57,7 @@ impl DeltaProof {
     }
 
     /// Verifies the delta proof against the instance (which carries the message).
-    pub fn verify(proof: &DeltaProof, instance: DeltaInstance) -> Result<(), ArmError> {
+    pub fn verify(proof: &DeltaProof, instance: &DeltaInstance) -> Result<(), ArmError> {
         // handle recid
         if proof.recid.to_byte() > 1 {
             return Err(ArmError::InvalidDeltaProof);
@@ -254,7 +254,7 @@ mod tests {
             message,
         };
 
-        DeltaProof::verify(&proof, instance).unwrap();
+        DeltaProof::verify(&proof, &instance).unwrap();
     }
 
     /// DeltaProof: serialize then deserialize via bincode must round-trip.

--- a/arm/src/transaction.rs
+++ b/arm/src/transaction.rs
@@ -105,9 +105,8 @@ impl Transaction {
 
         match &self.delta_proof {
             Delta::Proof(ref proof) => {
-                let msg = self.get_delta_msg()?;
                 let instance = self.delta()?;
-                DeltaProof::verify(&msg, proof, instance)?;
+                DeltaProof::verify(proof, instance)?;
 
                 // Check for nullifier duplication across all compliance units
                 self.nf_duplication_check()?;
@@ -215,34 +214,11 @@ impl Transaction {
         Ok(())
     }
 
-    /// Returns the DeltaInstance constructed from the sum of all actions' deltas.
+    /// Constructs the delta message by concatenating the delta messages of each action.
     ///
     /// When `aggregation` is present it is authoritative; see
     /// [`Self::nf_duplication_check`].
-    pub fn delta(&self) -> Result<DeltaInstance, ArmError> {
-        if let Some(agg) = &self.aggregation {
-            let mut points = Vec::with_capacity(agg.instance.actions.len());
-            for action in &agg.instance.actions {
-                points.push(action.delta_projective()?);
-            }
-            DeltaInstance::from_deltas(&points)
-        } else if let Some(actions) = &self.actions {
-            let mut points = Vec::with_capacity(actions.len());
-            for action in actions {
-                points.push(action.delta()?);
-            }
-            DeltaInstance::from_deltas(&points)
-        } else {
-            Err(ArmError::MissingActions)
-        }
-    }
-
-    /// Constructs the delta message by concatenating the delta messages
-    /// of each action.
-    ///
-    /// When `aggregation` is present it is authoritative; see
-    /// [`Self::nf_duplication_check`].
-    pub fn get_delta_msg(&self) -> Result<Vec<u8>, ArmError> {
+    fn get_delta_msg(&self) -> Result<Vec<u8>, ArmError> {
         if let Some(agg) = &self.aggregation {
             let mut msg = Vec::new();
             for action in &agg.instance.actions {
@@ -260,6 +236,31 @@ impl Transaction {
                 msg.extend(action.get_delta_msg()?);
             }
             Ok(msg)
+        } else {
+            Err(ArmError::MissingActions)
+        }
+    }
+
+    /// Returns the DeltaInstance constructed from the sum of all actions' deltas and their message.
+    ///
+    /// When `aggregation` is present it is authoritative; see
+    /// [`Self::nf_duplication_check`].
+    pub fn delta(&self) -> Result<DeltaInstance, ArmError> {
+        let msg = self.get_delta_msg()?;
+        if let Some(agg) = &self.aggregation {
+            let points = agg
+                .instance
+                .actions
+                .iter()
+                .map(|a| a.delta_projective())
+                .collect::<Result<Vec<_>, _>>()?;
+            DeltaInstance::new(&points, msg)
+        } else if let Some(actions) = &self.actions {
+            let points = actions
+                .iter()
+                .map(|a| a.delta())
+                .collect::<Result<Vec<_>, _>>()?;
+            DeltaInstance::new(&points, msg)
         } else {
             Err(ArmError::MissingActions)
         }

--- a/arm/src/transaction.rs
+++ b/arm/src/transaction.rs
@@ -106,7 +106,7 @@ impl Transaction {
         match &self.delta_proof {
             Delta::Proof(ref proof) => {
                 let instance = self.delta()?;
-                DeltaProof::verify(proof, instance)?;
+                DeltaProof::verify(proof, &instance)?;
 
                 // Check for nullifier duplication across all compliance units
                 self.nf_duplication_check()?;
@@ -214,21 +214,21 @@ impl Transaction {
         Ok(())
     }
 
-    /// Constructs the delta message by concatenating the delta messages of each action.
+    /// Constructs the delta message as the concatenation of each action's
+    /// action tree root (32 bytes each).
     ///
     /// When `aggregation` is present it is authoritative; see
     /// [`Self::nf_duplication_check`].
     fn get_delta_msg(&self) -> Result<Vec<u8>, ArmError> {
         if let Some(agg) = &self.aggregation {
-            let msg = agg
-                .instance
-                .actions
-                .iter()
-                .flat_map(|a| a.action_tree_root.as_bytes().to_vec())
-                .collect();
+            let actions = &agg.instance.actions;
+            let mut msg = Vec::with_capacity(actions.len() * 32);
+            for a in actions {
+                msg.extend_from_slice(a.action_tree_root.as_bytes());
+            }
             Ok(msg)
         } else if let Some(actions) = &self.actions {
-            let mut msg = Vec::new();
+            let mut msg = Vec::with_capacity(actions.len() * 32);
             for action in actions {
                 msg.extend(action.get_delta_msg()?);
             }
@@ -238,7 +238,8 @@ impl Transaction {
         }
     }
 
-    /// Returns the DeltaInstance constructed from the sum of all actions' deltas and their message.
+    /// Returns the DeltaInstance constructed from the sum of all actions'
+    /// deltas and their message.
     ///
     /// When `aggregation` is present it is authoritative; see
     /// [`Self::nf_duplication_check`].

--- a/arm/src/transaction.rs
+++ b/arm/src/transaction.rs
@@ -220,15 +220,12 @@ impl Transaction {
     /// [`Self::nf_duplication_check`].
     fn get_delta_msg(&self) -> Result<Vec<u8>, ArmError> {
         if let Some(agg) = &self.aggregation {
-            let mut msg = Vec::new();
-            for action in &agg.instance.actions {
-                for consumed in &action.consumed_publics {
-                    msg.extend_from_slice(consumed.resource_nullifier.as_bytes());
-                }
-                for created in &action.created_publics {
-                    msg.extend_from_slice(created.resource_commitment.as_bytes());
-                }
-            }
+            let msg = agg
+                .instance
+                .actions
+                .iter()
+                .flat_map(|a| a.action_tree_root.as_bytes().to_vec())
+                .collect();
             Ok(msg)
         } else if let Some(actions) = &self.actions {
             let mut msg = Vec::new();

--- a/arm_tests/arm_test_app/src/lib.rs
+++ b/arm_tests/arm_test_app/src/lib.rs
@@ -4,6 +4,7 @@
 
 use anoma_rm_risc0::{
     action::Action,
+    action_tree::ActionTree,
     compliance::ComplianceWitness,
     compliance_unit::ComplianceUnit,
     constants::{global_kind_table, init_kind_table_from_file},
@@ -187,7 +188,7 @@ impl Tester {
             .collect();
 
         let tags: Vec<Digest> = entries.iter().map(|(tag, ..)| *tag).collect();
-        let action_tree = Action::construct_action_tree(&tags);
+        let action_tree = ActionTree::new(tags);
 
         let logic_verifiers = entries
             .into_iter()


### PR DESCRIPTION
## Summary

- `DeltaInstance` now carries the signed `message` alongside `verifying_key`, making it a self-contained unit of public input. `DeltaProof::verify` drops its separate `message` parameter and reads from the instance instead.
- `DeltaInstance::from_deltas` renamed to `::new`; `get_delta_msg` made private; `Transaction::delta()` builds both the verifying key and the message in one call.
- The delta message itself is redefined: instead of concatenating every nullifier and commitment, each action contributes exactly its **action tree root** (32 bytes). This aligns the binding with the commitment that logic proofs already verify against, and keeps message size constant per action regardless of resource count.