### PR TITLE
docs(merkle_path): clarify PADDING_LEAF is sha256("EMPTY") not sha256("")

### DIFF
--- a/arm/src/merkle_path.rs
+++ b/arm/src/merkle_path.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 
 lazy_static! {
     /// A constant padding leaf used in Merkle trees.
-    /// This is the hash of an empty string.
+    /// This is sha256("EMPTY") — the SHA-256 hash of the five-byte ASCII string "EMPTY",
+    /// matching the EVM protocol adapter's `SHA256.EMPTY_HASH`. Not to be confused with
+    /// sha256("") (e3b0c442…), which is the empty kind table commitment.
     pub static ref PADDING_LEAF: Digest =
         Digest::from_hex("cc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b06")
             .unwrap();


### PR DESCRIPTION
close #254 