### PR TITLE
refactor(compliance): take Vec by value in ComplianceWitness constructor

### DIFF
--- a/arm/src/compliance.rs
+++ b/arm/src/compliance.rs
@@ -92,8 +92,8 @@ impl ComplianceWitness {
     /// Creates a new compliance witness from the given resources. It uses the
     /// initial root for ephemeral resources.
     pub fn from_resources(
-        consumed_data: &[ConsumedResourceWitness],
-        created_resources: &[Resource],
+        consumed_data: Vec<ConsumedResourceWitness>,
+        created_resources: Vec<Resource>,
         kind_table: Vec<KindTableEntry>,
     ) -> Self {
         Self::from_resources_with_ephemeral_root(
@@ -107,8 +107,8 @@ impl ComplianceWitness {
     /// Creates a new compliance witness from the given resources and a valid
     /// root when consuming an ephemeral resource.
     pub fn from_resources_with_ephemeral_root(
-        consumed_data: &[ConsumedResourceWitness],
-        created_resources: &[Resource],
+        consumed_data: Vec<ConsumedResourceWitness>,
+        created_resources: Vec<Resource>,
         valid_root: Digest,
         kind_table: Vec<KindTableEntry>,
     ) -> Self {
@@ -127,15 +127,15 @@ impl ComplianceWitness {
     /// Creates a new compliance witness from each of its component parts.
     /// The other constructors are convenience wrappers that fill in defaults.
     fn from_parts(
-        consumed_data: &[ConsumedResourceWitness],
-        created_resources: &[Resource],
+        consumed_data: Vec<ConsumedResourceWitness>,
+        created_resources: Vec<Resource>,
         ephemeral_root: Digest,
         rcv: &[u8],
         kind_table: Vec<KindTableEntry>,
     ) -> ComplianceWitness {
         ComplianceWitness {
-            consumed_data: consumed_data.to_vec(),
-            created_resources: created_resources.to_vec(),
+            consumed_data,
+            created_resources,
             ephemeral_root,
             rcv: rcv.to_vec(),
             kind_table,

--- a/arm_tests/arm_test_app/src/lib.rs
+++ b/arm_tests/arm_test_app/src/lib.rs
@@ -150,8 +150,8 @@ impl Tester {
 
         init_test_kind_table();
         let compliance_witness = ComplianceWitness::from_resources(
-            &self.consumed_data[self.current],
-            &self.created_resources[self.current],
+            self.consumed_data[self.current].clone(),
+            self.created_resources[self.current].clone(),
             global_kind_table().to_vec(),
         );
         self.rcvs.push(compliance_witness.rcv.clone());
@@ -683,8 +683,8 @@ fn test_invalid_created_nonce_rejected() {
 
     init_test_kind_table();
     let witness = ComplianceWitness::from_resources(
-        &tester.consumed_data[0],
-        &tester.created_resources[0],
+        tester.consumed_data[0].clone(),
+        tester.created_resources[0].clone(),
         global_kind_table().to_vec(),
     );
 


### PR DESCRIPTION
close #255 

The constructors now take owned Vecs and the two callers clone at the call site (which is equivalent to the previous internal to_vec(), but ownership is now explicit at the boundary). 